### PR TITLE
Removed host ports from mq example apps

### DIFF
--- a/apps/fabric8-mq-consumer/pom.xml
+++ b/apps/fabric8-mq-consumer/pom.xml
@@ -33,9 +33,6 @@
     <properties>
         <!-- fabric8 configuration -->
         <docker.dataImage>${env.DOCKER_REGISTRY}/fabric8/${project.artifactId}:${project.version}</docker.dataImage>
-        <docker.port.container.amq>${activemq.container.port}</docker.port.container.amq>
-        <docker.port.host.amq>${activemq.host.port}</docker.port.host.amq>
-        <docker.port.host.jolokia>9603</docker.port.host.jolokia>
 
         <fabric8.kubernetes.name>fabric8MQConsumer</fabric8.kubernetes.name>
         <fabric8.env.AMQ_SERVICE_ID>FABRIC8MQ</fabric8.env.AMQ_SERVICE_ID>

--- a/apps/fabric8-mq-producer/pom.xml
+++ b/apps/fabric8-mq-producer/pom.xml
@@ -33,9 +33,6 @@
     <properties>
         <!-- fabric8 configuration -->
         <docker.dataImage>${env.DOCKER_REGISTRY}/fabric8/${project.artifactId}:${project.version}</docker.dataImage>
-        <docker.port.container.amq>${activemq.container.port}</docker.port.container.amq>
-        <docker.port.host.amq>${activemq.host.port}</docker.port.host.amq>
-        <docker.port.host.jolokia>9602</docker.port.host.jolokia>
 
         <fabric8.kubernetes.name>fabric8MQCProducer</fabric8.kubernetes.name>
         <fabric8.env.AMQ_SERVICE_ID>FABRIC8MQ</fabric8.env.AMQ_SERVICE_ID>

--- a/apps/fabric8-mq/pom.xml
+++ b/apps/fabric8-mq/pom.xml
@@ -36,8 +36,6 @@
     <!-- fabric8 configuration -->
     <docker.dataImage>${env.DOCKER_REGISTRY}/fabric8/${project.artifactId}:${project.version}</docker.dataImage>
     <docker.port.container.amq>${activemq.container.port}</docker.port.container.amq>
-    <docker.port.host.amq>${activemq.host.port}</docker.port.host.amq>
-    <docker.port.host.jolokia>9802</docker.port.host.jolokia>
 
     <fabric8.kubernetes.name>fabric8MQ</fabric8.kubernetes.name>
     <fabric8.label.container>java</fabric8.label.container>

--- a/apps/pom.xml
+++ b/apps/pom.xml
@@ -31,9 +31,7 @@
   <name>Fabric8 :: Apps</name>
 
   <properties>
-    <activemq.host.port>6161</activemq.host.port>
     <activemq.container.port>6162</activemq.container.port>
-    <activemq.container.host>6161</activemq.container.host>
     <activemq.service.port>6163</activemq.service.port>
     <httpgateway.port>9000</httpgateway.port>
 


### PR DESCRIPTION
Removed host ports as we use kube services instead, it also avoids port conflicts so we can scale up multiple apps on one minion.
