### PR TITLE
Use older version of felix fileinstall to avoid CPU spike due bug in poj...

### DIFF
--- a/quickstarts/karaf/cxf/camel-cxf-code-first/pom.xml
+++ b/quickstarts/karaf/cxf/camel-cxf-code-first/pom.xml
@@ -105,6 +105,18 @@
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-test-blueprint</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>org.apache.felix.fileinstall</artifactId>
+        </exclusion>
+      </exclusions>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.felix</groupId>
+      <artifactId>org.apache.felix.fileinstall</artifactId>
+      <version>3.2.8</version>
       <scope>test</scope>
     </dependency>
 

--- a/quickstarts/karaf/cxf/camel-cxf-contract-first/pom.xml
+++ b/quickstarts/karaf/cxf/camel-cxf-contract-first/pom.xml
@@ -107,9 +107,20 @@
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-test-blueprint</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>org.apache.felix.fileinstall</artifactId>
+        </exclusion>
+      </exclusions>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.apache.felix</groupId>
+      <artifactId>org.apache.felix.fileinstall</artifactId>
+      <version>3.2.8</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>


### PR DESCRIPTION
...osr. Await for Camel 2.14.1 release which has this out of the box in camel-test-blueprint.
