### PR TITLE
use more concise docker container names so they make it into the public hub

### DIFF
--- a/quickstarts/karaf/beginner/camel-cbr/pom.xml
+++ b/quickstarts/karaf/beginner/camel-cbr/pom.xml
@@ -46,7 +46,7 @@
 
     <docker.from>fabric8/karaf-2.4</docker.from>
     <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+    <docker.image>${docker.registryPrefix}fabric8/quickstart-karaf-camelcbr:${project.version}</docker.image>
     <docker.assemblyDescriptor>${basedir}/src/main/fabric8/assembly.xml</docker.assemblyDescriptor>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>8181</docker.port.container.http>

--- a/quickstarts/karaf/beginner/camel-eips/pom.xml
+++ b/quickstarts/karaf/beginner/camel-eips/pom.xml
@@ -45,7 +45,7 @@
 
     <docker.from>fabric8/karaf-2.4</docker.from>
     <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+    <docker.image>${docker.registryPrefix}fabric8/quickstart-karaf-cameleip:${project.version}</docker.image>
     <docker.assemblyDescriptor>${basedir}/src/main/fabric8/assembly.xml</docker.assemblyDescriptor>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>8181</docker.port.container.http>

--- a/quickstarts/karaf/beginner/camel-errorhandler/pom.xml
+++ b/quickstarts/karaf/beginner/camel-errorhandler/pom.xml
@@ -46,7 +46,7 @@
 
     <docker.from>fabric8/karaf-2.4</docker.from>
     <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+    <docker.image>${docker.registryPrefix}fabric8/quickstart-karaf-camelerr:${project.version}</docker.image>
     <docker.assemblyDescriptor>${basedir}/src/main/fabric8/assembly.xml</docker.assemblyDescriptor>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>8181</docker.port.container.http>

--- a/quickstarts/karaf/beginner/camel-log-wiki/pom.xml
+++ b/quickstarts/karaf/beginner/camel-log-wiki/pom.xml
@@ -46,7 +46,7 @@
 
     <docker.from>fabric8/karaf-2.4</docker.from>
     <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+    <docker.image>${docker.registryPrefix}fabric8/quickstart-karaf-camelwiki:${project.version}</docker.image>
     <docker.assemblyDescriptor>${basedir}/src/main/fabric8/assembly.xml</docker.assemblyDescriptor>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>8181</docker.port.container.http>

--- a/quickstarts/karaf/beginner/camel-log/pom.xml
+++ b/quickstarts/karaf/beginner/camel-log/pom.xml
@@ -46,7 +46,7 @@
 
     <docker.from>fabric8/karaf-2.4</docker.from>
     <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+    <docker.image>${docker.registryPrefix}fabric8/quickstart-karaf-camellog:${project.version}</docker.image>
     <docker.assemblyDescriptor>${basedir}/src/main/fabric8/assembly.xml</docker.assemblyDescriptor>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>8181</docker.port.container.http>

--- a/quickstarts/karaf/camel-rest-sql/pom.xml
+++ b/quickstarts/karaf/camel-rest-sql/pom.xml
@@ -47,7 +47,7 @@
 
     <docker.from>fabric8/karaf-2.4</docker.from>
     <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+    <docker.image>${docker.registryPrefix}fabric8/quickstart-karaf-camelrest:${project.version}</docker.image>
     <docker.assemblyDescriptor>${basedir}/src/main/fabric8/assembly.xml</docker.assemblyDescriptor>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>8181</docker.port.container.http>


### PR DESCRIPTION
use more concise docker container names so they make it into the public hub
