### PR TITLE
Changed to d-m-p 0.13.5 and jboss-jdk base image for java quickstarts

### DIFF
--- a/quickstarts/java/camel-cdi-http/pom.xml
+++ b/quickstarts/java/camel-cdi-http/pom.xml
@@ -38,17 +38,14 @@
 
     <!-- the version of the BOM, defining all the dependency versions -->
     <fabric8.version>2.2.35</fabric8.version>
-    <docker.maven.plugin.version>0.13.3</docker.maven.plugin.version>
+    <docker.maven.plugin.version>0.13.5</docker.maven.plugin.version>
 
-    <docker.from>docker.io/fabric8/java</docker.from>
-
+    <!-- Docker & Fabric8 Configs -->
+    <docker.from>fabric8/java-jboss-openjdk8-jdk:1.0.2</docker.from>
     <fabric8.dockerPrefix>docker.io/</fabric8.dockerPrefix>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerPrefix}${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
-    <docker.assemblyDescriptorRef>artifact-with-dependencies</docker.assemblyDescriptorRef>
-    <docker.port.container.jolokia>8778</docker.port.container.jolokia>
-    <docker.env.MAIN>org.apache.camel.cdi.Main</docker.env.MAIN>
- 
+
     <fabric8.label.component>${project.artifactId}</fabric8.label.component>
     <fabric8.label.container>java</fabric8.label.container>
     <fabric8.label.group>quickstarts</fabric8.label.group>
@@ -190,6 +187,26 @@
       </plugin>
 
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.10</version>
+        <executions>
+          <execution>
+            <id>add-classpath</id>
+            <phase>package</phase>
+            <goals>
+              <goal>build-classpath</goal>
+            </goals>
+            <configuration>
+              <prefix>.</prefix>
+              <includeScope>runtime</includeScope>
+              <outputFile>${project.build.directory}/classpath</outputFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>org.jolokia</groupId>
         <artifactId>docker-maven-plugin</artifactId>
         <version>${docker.maven.plugin.version}</version>
@@ -200,10 +217,12 @@
               <build>
                 <from>${docker.from}</from>
                 <assembly>
-                  <descriptorRef>${docker.assemblyDescriptorRef}</descriptorRef>
+                  <basedir>/app</basedir>
+                  <descriptorRef>artifact-with-dependencies</descriptorRef>
                 </assembly>
                 <env>
-                  <MAIN>${docker.env.MAIN}</MAIN>
+                  <JAVA_APP_JAR>${project.build.finalName}.jar</JAVA_APP_JAR>
+                  <JAVA_MAIN_CLASS>org.apache.camel.cdi.Main</JAVA_MAIN_CLASS>
                 </env>
               </build>
             </image>

--- a/quickstarts/java/camel-cdi-rest/pom.xml
+++ b/quickstarts/java/camel-cdi-rest/pom.xml
@@ -38,17 +38,14 @@
 
     <!-- the version of the BOM, defining all the dependency versions -->
     <fabric8.version>2.2.35</fabric8.version>
-    <docker.maven.plugin.version>0.13.3</docker.maven.plugin.version>
+    <docker.maven.plugin.version>0.13.5</docker.maven.plugin.version>
 
-    <docker.from>docker.io/fabric8/java</docker.from>
-
+    <!-- Docker & Fabric8 Configs -->
+    <docker.from>fabric8/java-jboss-openjdk8-jdk:1.0.2</docker.from>
     <fabric8.dockerPrefix>docker.io/</fabric8.dockerPrefix>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerPrefix}${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
-    <docker.assemblyDescriptorRef>artifact-with-dependencies</docker.assemblyDescriptorRef>
-    <docker.port.container.jolokia>8778</docker.port.container.jolokia>
-    <docker.env.MAIN>org.apache.camel.cdi.Main</docker.env.MAIN>
- 
+
     <fabric8.label.component>${project.artifactId}</fabric8.label.component>
     <fabric8.label.container>java</fabric8.label.container>
     <fabric8.label.group>quickstarts</fabric8.label.group>
@@ -188,6 +185,26 @@
         </executions>
       </plugin>
 
+            <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.10</version>
+        <executions>
+          <execution>
+            <id>add-classpath</id>
+            <phase>package</phase>
+            <goals>
+              <goal>build-classpath</goal>
+            </goals>
+            <configuration>
+              <prefix>.</prefix>
+              <includeScope>runtime</includeScope>
+              <outputFile>${project.build.directory}/classpath</outputFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>org.jolokia</groupId>
         <artifactId>docker-maven-plugin</artifactId>
@@ -199,10 +216,12 @@
               <build>
                 <from>${docker.from}</from>
                 <assembly>
-                  <descriptorRef>${docker.assemblyDescriptorRef}</descriptorRef>
+                  <basedir>/app</basedir>
+                  <descriptorRef>artifact-with-dependencies</descriptorRef>
                 </assembly>
                 <env>
-                  <MAIN>${docker.env.MAIN}</MAIN>
+                  <JAVA_APP_JAR>${project.build.finalName}.jar</JAVA_APP_JAR>
+                  <JAVA_MAIN_CLASS>org.apache.camel.cdi.Main</JAVA_MAIN_CLASS>
                 </env>
               </build>
             </image>

--- a/quickstarts/java/camel-cdi/pom.xml
+++ b/quickstarts/java/camel-cdi/pom.xml
@@ -38,16 +38,14 @@
 
     <!-- the version of the BOM, defining all the dependency versions -->
     <fabric8.version>2.2.35</fabric8.version>
-    <docker.maven.plugin.version>0.13.3</docker.maven.plugin.version>
+    <docker.maven.plugin.version>0.13.5</docker.maven.plugin.version>
 
-    <docker.from>docker.io/fabric8/java</docker.from>
 
+    <!-- Docker & Fabric8 Configs -->
+    <docker.from>fabric8/java-jboss-openjdk8-jdk:1.0.2</docker.from>
     <fabric8.dockerPrefix>docker.io/</fabric8.dockerPrefix>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerPrefix}${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
-    <docker.assemblyDescriptorRef>artifact-with-dependencies</docker.assemblyDescriptorRef>
-    <docker.port.container.jolokia>8778</docker.port.container.jolokia>
-    <docker.env.MAIN>org.apache.camel.cdi.Main</docker.env.MAIN>
 
     <fabric8.service.name>qs-java-camel-cdi</fabric8.service.name>
     <fabric8.service.headless>true</fabric8.service.headless>
@@ -169,6 +167,26 @@
       </plugin>
 
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.10</version>
+        <executions>
+          <execution>
+            <id>add-classpath</id>
+            <phase>package</phase>
+            <goals>
+              <goal>build-classpath</goal>
+            </goals>
+            <configuration>
+              <prefix>.</prefix>
+              <includeScope>runtime</includeScope>
+              <outputFile>${project.build.directory}/classpath</outputFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>fabric8-maven-plugin</artifactId>
         <version>${fabric8.version}</version>
@@ -181,6 +199,7 @@
             </goals>
           </execution>
           <execution>
+            <!--  Attach the dependency classpath to the artefact (with an classified 'classpath') -->
             <id>attach</id>
             <phase>package</phase>
             <goals>
@@ -201,10 +220,12 @@
               <build>
                 <from>${docker.from}</from>
                 <assembly>
-                  <descriptorRef>${docker.assemblyDescriptorRef}</descriptorRef>
+                  <basedir>/app</basedir>
+                  <descriptorRef>artifact-with-dependencies</descriptorRef>
                 </assembly>
                 <env>
-                  <MAIN>${docker.env.MAIN}</MAIN>
+                  <JAVA_APP_JAR>${project.build.finalName}.jar</JAVA_APP_JAR>
+                  <JAVA_MAIN_CLASS>org.apache.camel.cdi.Main</JAVA_MAIN_CLASS>
                 </env>
               </build>
             </image>

--- a/quickstarts/java/camel-spring/pom.xml
+++ b/quickstarts/java/camel-spring/pom.xml
@@ -41,16 +41,14 @@
 
     <!-- maven plugin versions -->
     <camel.version>2.15.3</camel.version>
-    <docker.maven.plugin.version>0.13.3</docker.maven.plugin.version>
+    <docker.maven.plugin.version>0.13.5</docker.maven.plugin.version>
 
-    <docker.from>docker.io/fabric8/java</docker.from>
 
+    <!-- Docker & Fabric8 Configs -->
+    <docker.from>fabric8/java-jboss-openjdk8-jdk:1.0.2</docker.from>
     <fabric8.dockerPrefix>docker.io/</fabric8.dockerPrefix>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerPrefix}${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
-    <docker.assemblyDescriptorRef>artifact-with-dependencies</docker.assemblyDescriptorRef>
-    <docker.port.container.jolokia>8778</docker.port.container.jolokia>
-    <docker.env.MAIN>org.apache.camel.spring.Main</docker.env.MAIN>
 
     <fabric8.label.component>${project.artifactId}</fabric8.label.component>
     <fabric8.label.container>java</fabric8.label.container>
@@ -179,6 +177,26 @@
       </plugin>
 
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.10</version>
+        <executions>
+          <execution>
+            <id>add-classpath</id>
+            <phase>package</phase>
+            <goals>
+              <goal>build-classpath</goal>
+            </goals>
+            <configuration>
+              <prefix>.</prefix>
+              <includeScope>runtime</includeScope>
+              <outputFile>${project.build.directory}/classpath</outputFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>org.jolokia</groupId>
         <artifactId>docker-maven-plugin</artifactId>
         <version>${docker.maven.plugin.version}</version>
@@ -189,10 +207,12 @@
               <build>
                 <from>${docker.from}</from>
                 <assembly>
-                  <descriptorRef>${docker.assemblyDescriptorRef}</descriptorRef>
+                  <basedir>/app</basedir>
+                  <descriptorRef>artifact-with-dependencies</descriptorRef>
                 </assembly>
                 <env>
-                  <MAIN>${docker.env.MAIN}</MAIN>
+                  <JAVA_APP_JAR>${project.build.finalName}.jar</JAVA_APP_JAR>
+                  <JAVA_MAIN_CLASS>org.apache.camel.spring.Main</JAVA_MAIN_CLASS>
                 </env>
               </build>
             </image>

--- a/quickstarts/java/cxf-cdi/README.md
+++ b/quickstarts/java/cxf-cdi/README.md
@@ -23,19 +23,20 @@ To use the application be sure to have deployed the quickstart in fabric8 as des
 
 You can use any browser to perform a HTTP GET.  This allows you to very easily test a few of the RESTful services we defined:
 
-Notice: As fabric8 assigns a free dynamic port to the Java container, the port number may vary on your system.
+Notice: As it depends on your OpenShift setup, the hostname (route) might vary. Verify with `oc get routes` which 
+hostname is valid for you
 
 Use this URL to display the root of the REST service, which also allows to access the WADL of the service:
 
-    http://localhost:8080/cxfcdi
+    http://quickstart-java-cxf-cdi.vagrant.f8/cxfcdi
 
 Use this URL to display the XML representation for customer 123:
 
-    http://localhost:8080/cxfcdi/cxfcdi/customerservice/customers/123
+    http://quickstart-java-cxf-cdi.vagrant.f8/cxfcdi/customerservice/customers/123
 
 You can also access the XML representation for order 223 ...
 
-    http://localhost:8080/rest/cxf/customerservice/orders/223
+    http://quickstart-java-cxf-cdi.vagrant.f8/rest/cxf/customerservice/customers/123
 
 **Note:** if you use Safari, you will only see the text elements but not the XML tags - you can view the entire document with 'View Source'
 
@@ -49,7 +50,7 @@ You can use a command-line utility, such as cURL or wget, to perform the HTTP re
     
     * Create a customer
  
-            curl -X POST -T src/test/resources/add_customer.xml -H "Content-Type: text/xml" http://localhost:8080/cxfcdi/cxfcdi/customerservice/customers
+            curl -X POST -T src/test/resources/add_customer.xml -H "Content-Type: text/xml" http://quickstart-java-cxf-cdi.vagrant.f8/cxfcdi/customerservice/customers
   
     * Retrieve the customer instance with id 123
     
@@ -57,11 +58,11 @@ You can use a command-line utility, such as cURL or wget, to perform the HTTP re
 
     * Update the customer instance with id 123
   
-            curl -X PUT -T src/test/resources/update_customer.xml -H "Content-Type: text/xml" http://localhost:8080/cxfcdi/cxfcdi/customerservice/customers
+            curl -X PUT -T src/test/resources/update_customer.xml -H "Content-Type: text/xml" http://quickstart-java-cxf-cdi.vagrant.f8/cxfcdi/customerservice/customers
 
     * Delete the customer instance with id 123
   
-             curl -X DELETE http://localhost:8080/cxfcdi/cxfcdi/customerservice/customers/123
+             curl -X DELETE http://quickstart-java-cxf-cdi.vagrant.f8/cxfcdi/customerservice/customers/123
 
 
 

--- a/quickstarts/java/cxf-cdi/pom.xml
+++ b/quickstarts/java/cxf-cdi/pom.xml
@@ -42,24 +42,19 @@
 
     <!-- versions for use in mvn plugins as we cannot inherit them from a BOM -->
     <cxf.version>3.0.4</cxf.version>
-    <docker.maven.plugin.version>0.13.3</docker.maven.plugin.version>
+    <docker.maven.plugin.version>0.13.5</docker.maven.plugin.version>
     <org.eclipse.jetty.version>9.2.10.v20150310</org.eclipse.jetty.version>
 
     <http.port>9092</http.port>
 
-    <docker.from>docker.io/fabric8/java</docker.from>
-
+    <!-- Docker & Fabric8 Configs -->
+    <docker.from>fabric8/java-jboss-openjdk8-jdk:1.0.2</docker.from>
     <fabric8.dockerPrefix>docker.io/</fabric8.dockerPrefix>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerPrefix}${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
-    <docker.assemblyDescriptorRef>artifact-with-dependencies</docker.assemblyDescriptorRef>
-    <docker.env.MAIN>io.fabric8.quickstarts.cxfcdi.ApplicationStarter</docker.env.MAIN>
-    <docker.port.container.http>${http.port}</docker.port.container.http>
-    <docker.port.container.jolokia>8778</docker.port.container.jolokia>
-    <docker.port.container.metrics>9779</docker.port.container.metrics>
 
     <fabric8.service.name>quickstart-java-cxf-cdi</fabric8.service.name>
-    <fabric8.service.port>9002</fabric8.service.port>
+    <fabric8.service.port>80</fabric8.service.port>
     <fabric8.service.containerPort>${http.port}</fabric8.service.containerPort>
     <fabric8.annotations.service.servicePath>quickstart-java-cxf-cdi/cxfcdi</fabric8.annotations.service.servicePath>
     <fabric8.annotations.service.protocol>REST</fabric8.annotations.service.protocol>
@@ -322,6 +317,26 @@
       </plugin>
 
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.10</version>
+        <executions>
+          <execution>
+            <id>add-classpath</id>
+            <phase>package</phase>
+            <goals>
+              <goal>build-classpath</goal>
+            </goals>
+            <configuration>
+              <prefix>.</prefix>
+              <includeScope>runtime</includeScope>
+              <outputFile>${project.build.directory}/classpath</outputFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>org.jolokia</groupId>
         <artifactId>docker-maven-plugin</artifactId>
         <version>${docker.maven.plugin.version}</version>
@@ -332,14 +347,15 @@
               <build>
                 <from>${docker.from}</from>
                 <assembly>
-                  <descriptorRef>${docker.assemblyDescriptorRef}</descriptorRef>
+                  <basedir>/app</basedir>
+                  <descriptorRef>artifact-with-dependencies</descriptorRef>
                 </assembly>
                 <env>
-                  <MAIN>${docker.env.MAIN}</MAIN>
+                  <JAVA_APP_JAR>${project.build.finalName}.jar</JAVA_APP_JAR>
+                  <JAVA_MAIN_CLASS>io.fabric8.quickstarts.cxfcdi.ApplicationStarter</JAVA_MAIN_CLASS>
                   <HTTP_PORT>${http.port}</HTTP_PORT>
                 </env>
                 <ports>
-                  <port>8778</port>
                   <port>${http.port}</port>
                 </ports>
               </build>

--- a/quickstarts/java/cxf-cdi/src/main/java/io/fabric8/quickstarts/cxfcdi/ApplicationStarter.java
+++ b/quickstarts/java/cxf-cdi/src/main/java/io/fabric8/quickstarts/cxfcdi/ApplicationStarter.java
@@ -45,16 +45,8 @@ public class ApplicationStarter {
             port = "8586";
         }
         Integer num = Integer.parseInt(port);
-        String service = Systems.getEnvVarOrSystemProperty("WEB_CONTEXT_PATH", "WEB_CONTEXT_PATH", "quickstart-java-cxf-cdi");
-        if (service == null) {
-            // and fallback to use environment variable
-            service = System.getenv("SERVICE");
-        }
-        if (service == null) {
-            // and use 'quickstart-java-cxf-cdi' by default
-            service = "quickstart-java-cxf-cdi";
-        }
-        String servicesPath = "/cxf/servicesList";
+        String service = Systems.getEnvVarOrSystemProperty("WEB_CONTEXT_PATH", "WEB_CONTEXT_PATH", "");
+        String servicesPath = "/servicesList";
 
         String servletContextPath = "/" + service;
         ManagedApi.setSingletonCxfServletContext(servletContextPath);
@@ -63,17 +55,7 @@ public class ApplicationStarter {
         System.out.println("View the services at:            http://localhost:" + port + servletContextPath + servicesPath);
         System.out.println("View an example REST service at: http://localhost:" + port + servletContextPath + "/cxfcdi/customerservice/customers/123");
         System.out.println();
-        String url = "http://localhost:" + port + servletContextPath;
-        if (!url.endsWith("/")) {
-           url += "/";
-        }
 
-/*
-        Map<String, String> env = System.getenv();
-        for (String envName : env.keySet()) {
-            System.out.format("%s=%s%n", envName, env.get(envName));
-        }
-*/
         final Server server = new Server(num);
 
         // Register and map the dispatcher servlet

--- a/quickstarts/java/cxf-cdi/src/test/java/io/fabric8/quickstarts/cxfcdi/CrmTest.java
+++ b/quickstarts/java/cxf-cdi/src/test/java/io/fabric8/quickstarts/cxfcdi/CrmTest.java
@@ -41,9 +41,9 @@ import java.net.URL;
  */
 public final class CrmTest {
 
-    public static final String CUSTOMER_TEST_URL = "http://localhost:8586/quickstart-java-cxf-cdi/cxfcdi/customerservice/customers/123";
-    public static final String PRODUCT_ORDER_TEST_URL = "http://localhost:8586/quickstart-java-cxf-cdi/cxfcdi/customerservice/orders/223/products/323";
-    public static final String CUSTOMER_SERVICE_URL = "http://localhost:8586/quickstart-java-cxf-cdi/cxfcdi/customerservice/customers";
+    public static final String CUSTOMER_TEST_URL = "http://localhost:8586/cxfcdi/customerservice/customers/123";
+    public static final String PRODUCT_ORDER_TEST_URL = "http://localhost:8586/cxfcdi/customerservice/orders/223/products/323";
+    public static final String CUSTOMER_SERVICE_URL = "http://localhost:8586/cxfcdi/customerservice/customers";
     private static final Logger LOG = LoggerFactory.getLogger(CrmTest.class);
     private URL url;
     private InputStream in;

--- a/quickstarts/java/jgroups-greeter/pom.xml
+++ b/quickstarts/java/jgroups-greeter/pom.xml
@@ -37,18 +37,14 @@
 
     <!-- versions for use in mvn plugins as we cannot inherit them from a BOM -->
     <fabric8.version>2.2.35</fabric8.version>
-    <docker.maven.plugin.version>0.13.3</docker.maven.plugin.version>
+    <docker.maven.plugin.version>0.13.5</docker.maven.plugin.version>
 
-    <docker.from>docker.io/fabric8/java</docker.from>
-
+    <!-- Docker & Fabric8 Configs -->
+    <docker.from>fabric8/java-jboss-openjdk8-jdk:1.0.2</docker.from>
     <fabric8.dockerPrefix>docker.io/</fabric8.dockerPrefix>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerPrefix}${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
-    <docker.assemblyDescriptorRef>artifact-with-dependencies</docker.assemblyDescriptorRef>
-    <docker.port.container.jolokia>8778</docker.port.container.jolokia>
-    <docker.port.container.jgroups>7800</docker.port.container.jgroups>
-    <docker.env.MAIN>io.fabric8.quickstarts.jgroups.greeter.Main</docker.env.MAIN>
-    <docker.env.JAVA_OPTIONS>-Djava.net.preferIPv4Stack=true</docker.env.JAVA_OPTIONS>
+    <jgroups.port>7800</jgroups.port>
 
     <fabric8.label.component>${project.artifactId}</fabric8.label.component>
     <fabric8.label.container>java</fabric8.label.container>
@@ -154,6 +150,26 @@
         </executions>
       </plugin>
 
+            <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.10</version>
+        <executions>
+          <execution>
+            <id>add-classpath</id>
+            <phase>package</phase>
+            <goals>
+              <goal>build-classpath</goal>
+            </goals>
+            <configuration>
+              <prefix>.</prefix>
+              <includeScope>runtime</includeScope>
+              <outputFile>${project.build.directory}/classpath</outputFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>org.jolokia</groupId>
         <artifactId>docker-maven-plugin</artifactId>
@@ -165,15 +181,17 @@
               <build>
                 <from>${docker.from}</from>
                 <assembly>
-                  <descriptorRef>${docker.assemblyDescriptorRef}</descriptorRef>
+                  <basedir>/app</basedir>
+                  <descriptorRef>artifact-with-dependencies</descriptorRef>
                 </assembly>
                 <env>
-                  <MAIN>${docker.env.MAIN}</MAIN>
-                  <JGROUPS_PORT>${docker.port.container.jgroups}</JGROUPS_PORT>
-                  <JAVA_OPTIONS>${docker.env.JAVA_OPTIONS}</JAVA_OPTIONS>
+                  <JAVA_APP_JAR>${project.build.finalName}.jar</JAVA_APP_JAR>
+                  <JAVA_MAIN_CLASS>io.fabric8.quickstarts.jgroups.greeter.Main</JAVA_MAIN_CLASS>
+                  <JGROUPS_PORT>${jgroups.port}</JGROUPS_PORT>
+                  <JAVA_OPTIONS>-Djava.net.preferIPv4Stack=true</JAVA_OPTIONS>
                 </env>
                 <ports>
-                  <port>${docker.port.container.jgroups}</port>
+                  <port>${jgroups.port}</port>
                 </ports>
               </build>
             </image>

--- a/quickstarts/java/pom.xml
+++ b/quickstarts/java/pom.xml
@@ -34,11 +34,9 @@
   <modules>
     <module>camel-cdi</module>
     <module>camel-cdi-http</module>
-    <!--<module>camel-cdi-mq</module>-->
     <module>camel-cdi-rest</module>
     <module>camel-spring</module>
     <module>cxf-cdi</module>
-    <module>jgroups-greeter</module>
     <module>simple-fatjar</module>
     <module>simple-mainclass</module>
   </modules>

--- a/quickstarts/java/sandbox-camel-cdi-mq/camel-cdi-mq/pom.xml
+++ b/quickstarts/java/sandbox-camel-cdi-mq/camel-cdi-mq/pom.xml
@@ -46,15 +46,13 @@
     <fabric8.version>2.2.35</fabric8.version>
 
     <!-- versions for use in mvn plugins as we cannot inherit them from a BOM -->
-    <docker.maven.plugin.version>0.13.3</docker.maven.plugin.version>
-    <docker.from>docker.io/fabric8/java</docker.from>
+    <docker.maven.plugin.version>0.13.5</docker.maven.plugin.version>
 
+    <!-- Docker & Fabric8 Configs -->
+    <docker.from>fabric8/java-jboss-openjdk8-jdk:1.0.2</docker.from>
     <fabric8.dockerPrefix>docker.io/</fabric8.dockerPrefix>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerPrefix}${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
-    <docker.assemblyDescriptorRef>artifact-with-dependencies</docker.assemblyDescriptorRef>
-    <docker.port.container.jolokia>8778</docker.port.container.jolokia>
-    <docker.env.MAIN>org.apache.camel.cdi.Main</docker.env.MAIN>
 
     <fabric8.label.component>${project.artifactId}</fabric8.label.component>
     <fabric8.label.container>java</fabric8.label.container>
@@ -210,6 +208,26 @@
         </executions>
       </plugin>
 
+            <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.10</version>
+        <executions>
+          <execution>
+            <id>add-classpath</id>
+            <phase>package</phase>
+            <goals>
+              <goal>build-classpath</goal>
+            </goals>
+            <configuration>
+              <prefix>.</prefix>
+              <includeScope>runtime</includeScope>
+              <outputFile>${project.build.directory}/classpath</outputFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>org.jolokia</groupId>
         <artifactId>docker-maven-plugin</artifactId>
@@ -221,10 +239,12 @@
               <build>
                 <from>${docker.from}</from>
                 <assembly>
-                  <descriptorRef>${docker.assemblyDescriptorRef}</descriptorRef>
+                  <basedir>/app</basedir>
+                  <descriptorRef>artifact-with-dependencies</descriptorRef>
                 </assembly>
                 <env>
-                  <MAIN>${docker.env.MAIN}</MAIN>
+                  <JAVA_APP_JAR>${project.build.finalName}.jar</JAVA_APP_JAR>
+                  <JAVA_MAIN_CLASS>org.apache.camel.cdi.Main</JAVA_MAIN_CLASS>
                 </env>
               </build>
             </image>

--- a/quickstarts/java/simple-fatjar/pom.xml
+++ b/quickstarts/java/simple-fatjar/pom.xml
@@ -38,16 +38,13 @@
 
     <!-- versions for use in mvn plugins as we cannot inherit them from a BOM -->
     <fabric8.version>2.2.35</fabric8.version>
-    <docker.maven.plugin.version>0.13.3</docker.maven.plugin.version>
+    <docker.maven.plugin.version>0.13.5</docker.maven.plugin.version>
 
-    <docker.from>docker.io/fabric8/java</docker.from>
-
+    <!-- Docker & Fabric8 Configs -->
+    <docker.from>fabric8/java-jboss-openjdk8-jdk:1.0.2</docker.from>
     <fabric8.dockerPrefix>docker.io/</fabric8.dockerPrefix>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerPrefix}${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
-    <docker.assemblyDescriptorRef>artifact</docker.assemblyDescriptorRef>
-    <docker.port.container.jolokia>8778</docker.port.container.jolokia>
-    <docker.env.JAR>${project.artifactId}-${project.version}.jar</docker.env.JAR>
 
     <fabric8.label.component>${project.artifactId}</fabric8.label.component>
     <fabric8.label.container>java</fabric8.label.container>
@@ -150,10 +147,11 @@
               <build>
                 <from>${docker.from}</from>
                 <assembly>
-                  <descriptorRef>${docker.assemblyDescriptorRef}</descriptorRef>
+                  <basedir>/app</basedir>
+                  <descriptorRef>artifact</descriptorRef>
                 </assembly>
                 <env>
-                  <JAR>${docker.env.JAR}</JAR>
+                  <JAVA_APP_JAR>${project.build.finalName}.jar</JAVA_APP_JAR>
                 </env>
               </build>
             </image>

--- a/quickstarts/java/simple-mainclass/pom.xml
+++ b/quickstarts/java/simple-mainclass/pom.xml
@@ -43,16 +43,13 @@
 
     <!-- versions for use in mvn plugins as we cannot inherit them from a BOM -->
     <fabric8.version>2.2.35</fabric8.version>
-    <docker.maven.plugin.version>0.13.3</docker.maven.plugin.version>
+    <docker.maven.plugin.version>0.13.5</docker.maven.plugin.version>
 
-    <docker.from>docker.io/fabric8/java</docker.from>
-
+    <!-- Docker & Fabric8 Configs -->
+    <docker.from>fabric8/java-jboss-openjdk8-jdk:1.0.2</docker.from>
     <fabric8.dockerPrefix>docker.io/</fabric8.dockerPrefix>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerPrefix}${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
-    <docker.assemblyDescriptorRef>artifact-with-dependencies</docker.assemblyDescriptorRef>
-    <docker.port.container.jolokia>8778</docker.port.container.jolokia>
-    <docker.env.MAIN>io.fabric8.quickstarts.java.simple.Main</docker.env.MAIN>
 
     <fabric8.label.component>${project.artifactId}</fabric8.label.component>
     <fabric8.label.container>java</fabric8.label.container>
@@ -123,6 +120,26 @@
       </plugin>
 
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.10</version>
+        <executions>
+          <execution>
+            <id>add-classpath</id>
+            <phase>package</phase>
+            <goals>
+              <goal>build-classpath</goal>
+            </goals>
+            <configuration>
+              <prefix>.</prefix>
+              <includeScope>runtime</includeScope>
+              <outputFile>${project.build.directory}/classpath</outputFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>org.jolokia</groupId>
         <artifactId>docker-maven-plugin</artifactId>
         <version>${docker.maven.plugin.version}</version>
@@ -133,10 +150,12 @@
               <build>
                 <from>${docker.from}</from>
                 <assembly>
-                  <descriptorRef>${docker.assemblyDescriptorRef}</descriptorRef>
+                  <basedir>/app</basedir>
+                  <descriptorRef>artifact-with-dependencies</descriptorRef>
                 </assembly>
                 <env>
-                  <MAIN>${docker.env.MAIN}</MAIN>
+                  <JAVA_APP_JAR>${project.build.finalName}.jar</JAVA_APP_JAR>
+                  <JAVA_MAIN_CLASS>io.fabric8.quickstarts.java.simple.Main</JAVA_MAIN_CLASS>
                 </env>
               </build>
             </image>


### PR DESCRIPTION
fabric8/java-jboss-openjdk8-jdk is now used as base image for the java quickstarts. Cleaned up a bit the properties, too.

Note, that the classpath is now properly created for flat classpath apps. This is done via the maven-dependency-plugin's 'buildClasspath' goal.

Updated to docker-maven-plugin 0.13.5, too.