### PR TITLE
Set classpath separator fix to ":" when creating classpath.

### DIFF
--- a/quickstart/cdi/camel-http/pom.xml
+++ b/quickstart/cdi/camel-http/pom.xml
@@ -197,10 +197,12 @@
             <id>add-classpath</id>
             <phase>package</phase>
             <goals>
+              <!--  create target/classpath for docker-maven-plugin's assembly to pick up  -->
               <goal>build-classpath</goal>
             </goals>
             <configuration>
               <prefix>.</prefix>
+              <pathSeparator>:</pathSeparator>
               <includeScope>runtime</includeScope>
               <outputFile>${project.build.directory}/classpath</outputFile>
             </configuration>

--- a/quickstart/cdi/camel-mq/pom.xml
+++ b/quickstart/cdi/camel-mq/pom.xml
@@ -221,10 +221,12 @@
             <id>add-classpath</id>
             <phase>package</phase>
             <goals>
+              <!--  create target/classpath for docker-maven-plugin's assembly to pick up  -->
               <goal>build-classpath</goal>
             </goals>
             <configuration>
               <prefix>.</prefix>
+              <pathSeparator>:</pathSeparator>
               <includeScope>runtime</includeScope>
               <outputFile>${project.build.directory}/classpath</outputFile>
             </configuration>

--- a/quickstart/cdi/camel/pom.xml
+++ b/quickstart/cdi/camel/pom.xml
@@ -176,10 +176,12 @@
             <id>add-classpath</id>
             <phase>package</phase>
             <goals>
+              <!--  create target/classpath for docker-maven-plugin's assembly to pick up  -->
               <goal>build-classpath</goal>
             </goals>
             <configuration>
               <prefix>.</prefix>
+              <pathSeparator>:</pathSeparator>
               <includeScope>runtime</includeScope>
               <outputFile>${project.build.directory}/classpath</outputFile>
             </configuration>
@@ -200,7 +202,6 @@
             </goals>
           </execution>
           <execution>
-            <!--  Attach the dependency classpath to the artefact (with an classified 'classpath') -->
             <id>attach</id>
             <phase>package</phase>
             <goals>

--- a/quickstart/cdi/cxf/pom.xml
+++ b/quickstart/cdi/cxf/pom.xml
@@ -331,10 +331,12 @@
             <id>add-classpath</id>
             <phase>package</phase>
             <goals>
+              <!--  create target/classpath for docker-maven-plugin's assembly to pick up  -->
               <goal>build-classpath</goal>
             </goals>
             <configuration>
               <prefix>.</prefix>
+              <pathSeparator>:</pathSeparator>
               <includeScope>runtime</includeScope>
               <outputFile>${project.build.directory}/classpath</outputFile>
             </configuration>

--- a/quickstart/java/camel-spring/pom.xml
+++ b/quickstart/java/camel-spring/pom.xml
@@ -186,10 +186,12 @@
             <id>add-classpath</id>
             <phase>package</phase>
             <goals>
+              <!--  create target/classpath for docker-maven-plugin's assembly to pick up  -->
               <goal>build-classpath</goal>
             </goals>
             <configuration>
               <prefix>.</prefix>
+              <pathSeparator>:</pathSeparator>
               <includeScope>runtime</includeScope>
               <outputFile>${project.build.directory}/classpath</outputFile>
             </configuration>

--- a/quickstart/java/simple-mainclass/pom.xml
+++ b/quickstart/java/simple-mainclass/pom.xml
@@ -130,10 +130,12 @@
             <id>add-classpath</id>
             <phase>package</phase>
             <goals>
+              <!--  create target/classpath for docker-maven-plugin's assembly to pick up  -->
               <goal>build-classpath</goal>
             </goals>
             <configuration>
               <prefix>.</prefix>
+              <pathSeparator>:</pathSeparator>
               <includeScope>runtime</includeScope>
               <outputFile>${project.build.directory}/classpath</outputFile>
             </configuration>


### PR DESCRIPTION
This is needed since when building the current path separator will be used by default which is ';' on Windows and which obviously won't work on Linux.

Please note that we soon switch over to hawt-app for creating the classpath which make this fix obsolete.

Fixes fabric8io/fabric8#4881