### PR TITLE
Resolves #809 Update Wildfly readme for qs

### DIFF
--- a/quickstart/war/wildfly/README.md
+++ b/quickstart/war/wildfly/README.md
@@ -1,57 +1,51 @@
-# Wildlfy QuickStart
+# War Wildlfy QuickStart
 
-This example shows a Wildfly quickstart on Kubernetes/Openshift with Fabric8.
-
-This quickstart exposes a simple application deployed on top of Wildfly 9.0.1.Final.
-
-There is a simple REST service. This service can be called from the home page of the application.
+This quickstart exposes a simple application with a simple REST service deployed on top of Wildfly 9.0.1.Final. 
+This service can be called from the home page of the application.
 
 The example is based on Markus Eisele blog post:
-
 http://blog.eisele.net/2015/07/running-wildfly-on-openshift-3-with-kubernetes-fabric8-on-windows.html
 
-# Installation
+### Building
 
-You'll need to have Kubernetes and openshift v3 installed and running on your machine.
+The example can be built with
 
-You can use the Fabric8-installer: https://github.com/fabric8io/fabric8-installer
+    mvn clean install
 
-In particular this vagrant image: https://github.com/fabric8io/fabric8-installer/tree/master/vagrant/openshift
+### Running the example in fabric8
 
-```
-mvn clean package docker:build
-mvn fabric8:json fabric8:apply
+It is assumed a running Kubernetes platform is already running. If not you can find details how to [get started](http://fabric8.io/guide/getStarted/index.html).
 
-```
+The example must be built first using
 
-You'll need to modify you `/etc/hosts` file by adding this address to `172.28.128.4` 
+    mvn clean install docker:build
 
-```
-172.28.128.4 quickstart-wildfly.vagrant.f8
+Then the example can be deployed using:
 
-```
+    mvn fabric8:json fabric8:apply
 
-Now you should see the homepage on http://quickstart-wildfly.vagrant.f8/. If you follow the "get greetings" link you should get the following message:
+When the example runs in fabric8, you can use the OpenShift client tool to inspect the status
 
-```
-Hi fabric8 you're receiving this message from pod <Pod_name>
+To list all the running pods:
 
-```
+    oc get pods
 
-## Calling the REST service from a shell script
+Then find the name of the pod that runs this quickstart, and output the logs from the running pods with:
 
-You can also call the REST service from a shell script. We have provided a script named `test-script.sh` (no script for windows)
-which will call the service once every five second for one hundred times. 
+    oc logs <name of pod>
 
-You may need to add execution permission to the script before you can execute it
+You can also use the fabric8 [web console](http://fabric8.io/guide/console.html) to manage the
+running pods, and view logs and much more.
 
-    chmod +x test-script.sh
+### Access services using a web browser
 
-And then run the script
+When the application is running, you can use a web browser to access the HTTP service. Assuming that you
+have a [Vagrant setup](http://fabric8.io/guide/getStarted/vagrant.html) you can access the application with
+`http://quickstart-wildfly.vagrant.f8/`.
 
-    ./test-script.sh
+Notice: As it depends on your OpenShift setup, the hostname (route) might vary. Verify with `oc get routes` which
+hostname is valid for you.
 
-While the script runs, you can try to scale up or down the number of pods on the REST service using either the fabric8 web console,
-or from the command line using the openshift client
+### More details
 
-    oc scale --replicas=3 replicationcontrollers quickstart-wildfly
+You can find more details about running the quickstart [examples](http://fabric8.io/guide/getStarted/example.html) on the website.


### PR DESCRIPTION
This PR resolves #809 

Now docs are aligned with other qs.

This particular qs cannot be run locally, because it was originally thought as an example of scaling.