### PR TITLE
#828 lets revert the use of mvn properties for now until we fix up the forge tooling to deal with this (or back out of doing it - whichever) - so that the forge wizard in the fabric8 console can still be used to create projects

### DIFF
--- a/quickstart/cdi/camel-http/pom.xml
+++ b/quickstart/cdi/camel-http/pom.xml
@@ -47,7 +47,6 @@
     <fabric8.dockerPrefix>docker.io/</fabric8.dockerPrefix>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerPrefix}${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
-    <docker.mainClass>org.apache.camel.cdi.Main</docker.mainClass>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
 
     <!--
@@ -213,7 +212,7 @@
             <id>hawt-app</id>
             <goals><goal>build</goal></goals>
             <configuration>
-              <javaMainClass>${docker.mainClass}</javaMainClass>
+              <javaMainClass>org.apache.camel.cdi.Main</javaMainClass>
             </configuration>
           </execution>
         </executions>
@@ -235,7 +234,7 @@
                 </assembly>
                 <env>
                   <JAVA_LIB_DIR>/deployments/hawt-app/lib</JAVA_LIB_DIR>
-                  <JAVA_MAIN_CLASS>${docker.mainClass}</JAVA_MAIN_CLASS>
+                  <JAVA_MAIN_CLASS>org.apache.camel.cdi.Main</JAVA_MAIN_CLASS>
                 </env>
               </build>
             </image>
@@ -249,7 +248,7 @@
         <artifactId>exec-maven-plugin</artifactId>
         <version>1.4.0</version>
         <configuration>
-          <mainClass>${docker.mainClass}</mainClass>
+          <mainClass>org.apache.camel.cdi.Main</mainClass>
         </configuration>
       </plugin>
 

--- a/quickstart/cdi/camel-jetty/pom.xml
+++ b/quickstart/cdi/camel-jetty/pom.xml
@@ -47,7 +47,6 @@
     <fabric8.dockerPrefix>docker.io/</fabric8.dockerPrefix>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerPrefix}${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
-    <docker.mainClass>org.apache.camel.cdi.Main</docker.mainClass>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>8080</docker.port.container.http>
 
@@ -210,7 +209,7 @@
             <id>hawt-app</id>
             <goals><goal>build</goal></goals>
             <configuration>
-              <javaMainClass>${docker.mainClass}</javaMainClass>
+              <javaMainClass>org.apache.camel.cdi.Main</javaMainClass>
             </configuration>
           </execution>
         </executions>
@@ -232,7 +231,7 @@
                 </assembly>
                 <env>
                   <JAVA_LIB_DIR>/deployments/hawt-app/lib</JAVA_LIB_DIR>
-                  <JAVA_MAIN_CLASS>${docker.mainClass}</JAVA_MAIN_CLASS>
+                  <JAVA_MAIN_CLASS>org.apache.camel.cdi.Main</JAVA_MAIN_CLASS>
                 </env>
               </build>
             </image>
@@ -246,7 +245,7 @@
         <artifactId>exec-maven-plugin</artifactId>
         <version>1.4.0</version>
         <configuration>
-          <mainClass>${docker.mainClass}</mainClass>
+          <mainClass>org.apache.camel.cdi.Main</mainClass>
         </configuration>
       </plugin>
 

--- a/quickstart/cdi/camel-mq/pom.xml
+++ b/quickstart/cdi/camel-mq/pom.xml
@@ -49,7 +49,6 @@
     <fabric8.dockerPrefix>docker.io/</fabric8.dockerPrefix>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerPrefix}${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
-    <docker.mainClass>org.apache.camel.cdi.Main</docker.mainClass>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
 
     <!--
@@ -228,7 +227,7 @@
             <id>hawt-app</id>
             <goals><goal>build</goal></goals>
             <configuration>
-              <javaMainClass>${docker.mainClass}</javaMainClass>
+              <javaMainClass>org.apache.camel.cdi.Main</javaMainClass>
             </configuration>
           </execution>
         </executions>
@@ -250,7 +249,7 @@
                 </assembly>
                 <env>
                   <JAVA_LIB_DIR>/deployments/hawt-app/lib</JAVA_LIB_DIR>
-                  <JAVA_MAIN_CLASS>${docker.mainClass}</JAVA_MAIN_CLASS>
+                  <JAVA_MAIN_CLASS>org.apache.camel.cdi.Main</JAVA_MAIN_CLASS>
                 </env>
               </build>
             </image>
@@ -264,7 +263,7 @@
         <artifactId>exec-maven-plugin</artifactId>
         <version>1.4.0</version>
         <configuration>
-          <mainClass>${docker.mainClass}</mainClass>
+          <mainClass>org.apache.camel.cdi.Main</mainClass>
         </configuration>
       </plugin>
 

--- a/quickstart/cdi/camel/pom.xml
+++ b/quickstart/cdi/camel/pom.xml
@@ -47,7 +47,6 @@
     <fabric8.dockerPrefix>docker.io/</fabric8.dockerPrefix>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerPrefix}${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
-    <docker.mainClass>org.apache.camel.cdi.Main</docker.mainClass>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
 
     <!--
@@ -214,7 +213,7 @@
             <id>hawt-app</id>
             <goals><goal>build</goal></goals>
             <configuration>
-              <javaMainClass>${docker.mainClass}</javaMainClass>
+              <javaMainClass>org.apache.camel.cdi.Main</javaMainClass>
             </configuration>
           </execution>
         </executions>
@@ -236,7 +235,7 @@
                 </assembly>
                 <env>
                   <JAVA_LIB_DIR>/deployments/hawt-app/lib</JAVA_LIB_DIR>
-                  <JAVA_MAIN_CLASS>${docker.mainClass}</JAVA_MAIN_CLASS>
+                  <JAVA_MAIN_CLASS>org.apache.camel.cdi.Main</JAVA_MAIN_CLASS>
                 </env>
               </build>
             </image>
@@ -250,7 +249,7 @@
         <artifactId>exec-maven-plugin</artifactId>
         <version>1.4.0</version>
         <configuration>
-          <mainClass>${docker.mainClass}</mainClass>
+          <mainClass>org.apache.camel.cdi.Main</mainClass>
         </configuration>
       </plugin>
     </plugins>

--- a/quickstart/cdi/cxf/pom.xml
+++ b/quickstart/cdi/cxf/pom.xml
@@ -49,7 +49,6 @@
     <fabric8.dockerPrefix>docker.io/</fabric8.dockerPrefix>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerPrefix}${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
-    <docker.mainClass>io.fabric8.quickstarts.cxfcdi.ApplicationStarter</docker.mainClass>
     <docker.port.container.http>${http.port}</docker.port.container.http>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.metrics>9779</docker.port.container.metrics>
@@ -372,7 +371,7 @@
             <id>hawt-app</id>
             <goals><goal>build</goal></goals>
             <configuration>
-              <javaMainClass>${docker.mainClass}</javaMainClass>
+              <javaMainClass>io.fabric8.quickstarts.cxfcdi.ApplicationStarter</javaMainClass>
             </configuration>
           </execution>
         </executions>
@@ -394,7 +393,7 @@
                 </assembly>
                 <env>
                   <JAVA_LIB_DIR>/deployments/hawt-app/lib</JAVA_LIB_DIR>
-                  <JAVA_MAIN_CLASS>${docker.mainClass}</JAVA_MAIN_CLASS>
+                  <JAVA_MAIN_CLASS>io.fabric8.quickstarts.cxfcdi.ApplicationStarter</JAVA_MAIN_CLASS>
                   <HTTP_PORT>${http.port}</HTTP_PORT>
                 </env>
                 <ports>
@@ -412,7 +411,7 @@
         <artifactId>exec-maven-plugin</artifactId>
         <version>1.4.0</version>
         <configuration>
-          <mainClass>${docker.mainClass}</mainClass>
+          <mainClass>io.fabric8.quickstarts.cxfcdi.ApplicationStarter</mainClass>
         </configuration>
       </plugin>
     </plugins>

--- a/quickstart/java/camel-spring/ReadMe.md
+++ b/quickstart/java/camel-spring/ReadMe.md
@@ -21,7 +21,7 @@ The example can be built with
 
 The example can be run locally using the following Maven goal:
 
-    mvn clean install exec:java
+    mvn camel:run
 
 
 ### Running the example in fabric8

--- a/quickstart/java/camel-spring/pom.xml
+++ b/quickstart/java/camel-spring/pom.xml
@@ -48,7 +48,6 @@
     <fabric8.dockerPrefix>docker.io/</fabric8.dockerPrefix>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerPrefix}${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
-    <docker.mainClass>org.apache.camel.spring.Main</docker.mainClass>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
 
     <!--
@@ -157,6 +156,13 @@
         </configuration>
       </plugin>
 
+      <!-- allows the route to be ran via 'mvn camel:run' -->
+      <plugin>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-maven-plugin</artifactId>
+        <version>${camel.version}</version>
+      </plugin>
+
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>fabric8-maven-plugin</artifactId>
@@ -188,7 +194,7 @@
             <id>hawt-app</id>
             <goals><goal>build</goal></goals>
             <configuration>
-              <javaMainClass>${docker.mainClass}</javaMainClass>
+              <javaMainClass>org.apache.camel.spring.Main</javaMainClass>
             </configuration>
           </execution>
         </executions>
@@ -210,7 +216,7 @@
                 </assembly>
                 <env>
                   <JAVA_LIB_DIR>/deployments/hawt-app/lib</JAVA_LIB_DIR>
-                  <JAVA_MAIN_CLASS>${docker.mainClass}</JAVA_MAIN_CLASS>
+                  <JAVA_MAIN_CLASS>org.apache.camel.spring.Main</JAVA_MAIN_CLASS>
                 </env>
               </build>
             </image>

--- a/quickstart/java/simple-fatjar/README.md
+++ b/quickstart/java/simple-fatjar/README.md
@@ -20,7 +20,7 @@ The example can be built with
 
 The example can be run locally using the following Maven goal:
 
-    mvn clean install exec:java
+    mvn exec:java
 
 
 ### Running the example in fabric8

--- a/quickstart/java/simple-fatjar/pom.xml
+++ b/quickstart/java/simple-fatjar/pom.xml
@@ -46,7 +46,6 @@
     <docker.from>fabric8/java-jboss-openjdk8-jdk:latest</docker.from>
     <fabric8.dockerPrefix>docker.io/</fabric8.dockerPrefix>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
-    <docker.mainClass>io.fabric8.quickstarts.java.simple.fatjar.Main</docker.mainClass>
     <docker.image>${fabric8.dockerPrefix}${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
 
     <fabric8.label.component>${project.artifactId}</fabric8.label.component>
@@ -103,7 +102,7 @@
               <createDependencyReducedPom>false</createDependencyReducedPom>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>${docker.mainClass}</mainClass>
+                  <mainClass>io.fabric8.quickstarts.java.simple.fatjar.Main</mainClass>
                 </transformer>
               </transformers>
             </configuration>
@@ -162,7 +161,7 @@
         <artifactId>exec-maven-plugin</artifactId>
         <version>1.4.0</version>
         <configuration>
-          <mainClass>${docker.mainClass}</mainClass>
+          <mainClass>io.fabric8.quickstarts.java.simple.fatjar.Main</mainClass>
         </configuration>
       </plugin>
 

--- a/quickstart/java/simple-mainclass/README.md
+++ b/quickstart/java/simple-mainclass/README.md
@@ -20,7 +20,7 @@ The example can be built with
 
 The example can be run locally using the following Maven goal:
 
-    mvn clean install exec:java
+    mvn exec:java
 
 
 ### Running the example in fabric8

--- a/quickstart/java/simple-mainclass/pom.xml
+++ b/quickstart/java/simple-mainclass/pom.xml
@@ -46,7 +46,6 @@
     <docker.from>fabric8/sti-java-jboss-jdk8:1.0.14</docker.from>
     <fabric8.dockerPrefix>docker.io/</fabric8.dockerPrefix>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
-    <docker.mainClass>io.fabric8.quickstarts.java.simple.Main</docker.mainClass>
     <docker.image>${fabric8.dockerPrefix}${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
 
@@ -121,7 +120,7 @@
             <id>hawt-app</id>
             <goals><goal>build</goal></goals>
             <configuration>
-              <javaMainClass>${docker.mainClass}</javaMainClass>
+              <javaMainClass>io.fabric8.quickstarts.java.simple.Main</javaMainClass>
             </configuration>
           </execution>
         </executions>
@@ -143,7 +142,7 @@
                 </assembly>
                 <env>
                   <JAVA_LIB_DIR>/deployments/hawt-app/lib</JAVA_LIB_DIR>
-                  <JAVA_MAIN_CLASS>${docker.mainClass}</JAVA_MAIN_CLASS>
+                  <JAVA_MAIN_CLASS>io.fabric8.quickstarts.java.simple.Main</JAVA_MAIN_CLASS>
                 </env>
               </build>
             </image>


### PR DESCRIPTION
#828 lets revert the use of mvn properties for now until we fix up the forge tooling to deal with this (or back out of doing it - whichever) - so that the forge wizard in the fabric8 console can still be used to create projects