### PR TITLE
Update to new base image + fix with openshift auth

### DIFF
--- a/quickstart/cdi/camel-http/pom.xml
+++ b/quickstart/cdi/camel-http/pom.xml
@@ -43,7 +43,7 @@
     <camel.version>2.16.0</camel.version>
 
     <!-- Docker & Fabric8 Configs -->
-    <docker.from>fabric8/s2i-java:1.1.0</docker.from>
+    <docker.from>fabric8/s2i-java:1.1.1</docker.from>
     <fabric8.dockerPrefix>docker.io/</fabric8.dockerPrefix>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerPrefix}${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
@@ -62,6 +62,7 @@
     <fabric8.metrics.port>9779</fabric8.metrics.port>
     <!-- End Prometheus metrics stuff -->
 
+    <fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>true</fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>
     <fabric8.label.component>${project.artifactId}</fabric8.label.component>
     <fabric8.label.container>java</fabric8.label.container>
     <fabric8.label.group>quickstarts</fabric8.label.group>

--- a/quickstart/cdi/camel-jetty/pom.xml
+++ b/quickstart/cdi/camel-jetty/pom.xml
@@ -59,6 +59,7 @@
     <fabric8.metrics.port>9779</fabric8.metrics.port>
     <!-- End Prometheus metrics stuff -->
 
+    <fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>true</fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>
     <fabric8.label.component>${project.artifactId}</fabric8.label.component>
     <fabric8.label.container>java</fabric8.label.container>
     <fabric8.label.group>quickstarts</fabric8.label.group>

--- a/quickstart/cdi/camel-mq/pom.xml
+++ b/quickstart/cdi/camel-mq/pom.xml
@@ -45,7 +45,7 @@
     <activemq.version>5.12.0</activemq.version>
 
     <!-- Docker & Fabric8 Configs -->
-    <docker.from>fabric8/s2i-java:1.1.0</docker.from>
+    <docker.from>fabric8/s2i-java:1.1.1</docker.from>
     <fabric8.dockerPrefix>docker.io/</fabric8.dockerPrefix>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerPrefix}${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
@@ -64,6 +64,7 @@
     <fabric8.metrics.port>9779</fabric8.metrics.port>
     <!-- End Prometheus metrics stuff -->
 
+    <fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>true</fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>
     <fabric8.label.component>${project.artifactId}</fabric8.label.component>
     <fabric8.label.container>java</fabric8.label.container>
     <fabric8.label.group>quickstarts</fabric8.label.group>

--- a/quickstart/cdi/camel/pom.xml
+++ b/quickstart/cdi/camel/pom.xml
@@ -43,7 +43,7 @@
     <camel.version>2.16.0</camel.version>
 
     <!-- Docker & Fabric8 Configs -->
-    <docker.from>fabric8/s2i-java:1.1.0</docker.from>
+    <docker.from>fabric8/s2i-java:1.1.1</docker.from>
     <fabric8.dockerPrefix>docker.io/</fabric8.dockerPrefix>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerPrefix}${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
@@ -62,6 +62,7 @@
     <fabric8.metrics.port>9779</fabric8.metrics.port>
     <!-- End Prometheus metrics stuff -->
 
+    <fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>true</fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>
     <fabric8.label.component>${project.artifactId}</fabric8.label.component>
     <fabric8.label.container>java</fabric8.label.container>
     <fabric8.label.group>quickstarts</fabric8.label.group>

--- a/quickstart/cdi/cxf/pom.xml
+++ b/quickstart/cdi/cxf/pom.xml
@@ -45,7 +45,7 @@
     <http.port>9092</http.port>
 
     <!-- Docker & Fabric8 Configs -->
-    <docker.from>fabric8/s2i-java:1.1.0</docker.from>
+    <docker.from>fabric8/s2i-java:1.1.1</docker.from>
     <fabric8.dockerPrefix>docker.io/</fabric8.dockerPrefix>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerPrefix}${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
@@ -64,6 +64,7 @@
     <fabric8.metrics.scrape>true</fabric8.metrics.scrape>
     <fabric8.metrics.port>9779</fabric8.metrics.port>
 
+    <fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>true</fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>
     <fabric8.label.container>java</fabric8.label.container>
     <fabric8.label.group>quickstarts</fabric8.label.group>
     <fabric8.label.component>${project.artifactId}</fabric8.label.component>

--- a/quickstart/java/camel-spring/pom.xml
+++ b/quickstart/java/camel-spring/pom.xml
@@ -44,7 +44,7 @@
     <commons-lang3.version>3.4</commons-lang3.version>
 
     <!-- Docker & Fabric8 Configs -->
-    <docker.from>fabric8/s2i-java:1.1.0</docker.from>
+    <docker.from>fabric8/s2i-java:1.1.1</docker.from>
     <fabric8.dockerPrefix>docker.io/</fabric8.dockerPrefix>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerPrefix}${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
@@ -63,6 +63,7 @@
     <fabric8.metrics.port>9779</fabric8.metrics.port>
     <!-- End Prometheus metrics stuff -->
 
+    <fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>true</fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>
     <fabric8.label.component>${project.artifactId}</fabric8.label.component>
     <fabric8.label.container>java</fabric8.label.container>
     <fabric8.label.group>quickstarts</fabric8.label.group>

--- a/quickstart/java/simple-fatjar/pom.xml
+++ b/quickstart/java/simple-fatjar/pom.xml
@@ -48,6 +48,7 @@
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerPrefix}${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
 
+    <fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>true</fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>
     <fabric8.label.component>${project.artifactId}</fabric8.label.component>
     <fabric8.label.container>java</fabric8.label.container>
     <fabric8.label.group>quickstarts</fabric8.label.group>

--- a/quickstart/java/simple-mainclass/pom.xml
+++ b/quickstart/java/simple-mainclass/pom.xml
@@ -43,12 +43,13 @@
     <commons-lang3.version>3.4</commons-lang3.version>
 
     <!-- Docker & Fabric8 Configs -->
-    <docker.from>fabric8/s2i-java:1.1.0</docker.from>
+    <docker.from>fabric8/s2i-java:1.1.1</docker.from>
     <fabric8.dockerPrefix>docker.io/</fabric8.dockerPrefix>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerPrefix}${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
 
+    <fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>true</fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>
     <fabric8.label.component>${project.artifactId}</fabric8.label.component>
     <fabric8.label.container>java</fabric8.label.container>
     <fabric8.label.group>quickstarts</fabric8.label.group>

--- a/quickstart/karaf/camel-amq/pom.xml
+++ b/quickstart/karaf/camel-amq/pom.xml
@@ -54,6 +54,7 @@
     <docker.port.container.http>8181</docker.port.container.http>
     <fabric8.env.AMQ_SERVICE_ID>FABRIC8MQ</fabric8.env.AMQ_SERVICE_ID>
 
+    <fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>true</fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>
     <fabric8.label.component>${project.artifactId}</fabric8.label.component>
     <fabric8.label.container>karaf</fabric8.label.container>
     <fabric8.label.group>quickstarts</fabric8.label.group>

--- a/quickstart/karaf/camel-log/pom.xml
+++ b/quickstart/karaf/camel-log/pom.xml
@@ -44,7 +44,7 @@
     <karaf.version>2.4.3</karaf.version>
     <karaf.plugin.version>4.0.2</karaf.plugin.version>
 
-    <docker.from>fabric8/s2i-karaf:1.1.0</docker.from>
+    <docker.from>fabric8/s2i-karaf:1.1.1</docker.from>
     <fabric8.dockerPrefix>docker.io/</fabric8.dockerPrefix>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerPrefix}${fabric8.dockerUser}quickstart-karaf-camellog:${project.version}</docker.image>
@@ -52,6 +52,7 @@
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>8181</docker.port.container.http>
 
+    <fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>true</fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>
     <fabric8.label.component>${project.artifactId}</fabric8.label.component>
     <fabric8.label.container>karaf</fabric8.label.container>
     <fabric8.label.group>quickstarts</fabric8.label.group>

--- a/quickstart/karaf/camel-rest-sql/pom.xml
+++ b/quickstart/karaf/camel-rest-sql/pom.xml
@@ -46,7 +46,7 @@
     <karaf.plugin.version>4.0.2</karaf.plugin.version>
     <spring.tx.feature.version>3.2.11.RELEASE_1</spring.tx.feature.version>
 
-    <docker.from>fabric8/s2i-karaf:1.1.0</docker.from>
+    <docker.from>fabric8/s2i-karaf:1.1.1</docker.from>
     <fabric8.dockerPrefix>docker.io/</fabric8.dockerPrefix>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerPrefix}${fabric8.dockerUser}quickstart-karaf-camelrest:${project.version}</docker.image>
@@ -58,6 +58,7 @@
     <fabric8.service.port>9411</fabric8.service.port>
     <fabric8.service.containerPort>8181</fabric8.service.containerPort>
 
+    <fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>true</fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>
     <fabric8.label.component>${project.artifactId}</fabric8.label.component>
     <fabric8.label.container>karaf</fabric8.label.container>
     <fabric8.label.group>quickstarts</fabric8.label.group>

--- a/quickstart/karaf/cxf-rest/pom.xml
+++ b/quickstart/karaf/cxf-rest/pom.xml
@@ -53,7 +53,7 @@
     <jackson-module-scala-version>2.1.5_2</jackson-module-scala-version>
     <swagger-scala-version>2.10.2</swagger-scala-version>
 
-    <docker.from>fabric8/s2i-karaf:1.1.0</docker.from>
+    <docker.from>fabric8/s2i-karaf:1.1.1</docker.from>
     <fabric8.dockerPrefix>docker.io/</fabric8.dockerPrefix>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerPrefix}${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
@@ -65,6 +65,7 @@
     <fabric8.service.port>9412</fabric8.service.port>
     <fabric8.service.containerPort>8181</fabric8.service.containerPort>
 
+    <fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>true</fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>
     <fabric8.label.component>${project.artifactId}</fabric8.label.component>
     <fabric8.label.container>karaf</fabric8.label.container>
     <fabric8.label.group>quickstarts</fabric8.label.group>

--- a/quickstart/spring-boot/camel/pom.xml
+++ b/quickstart/spring-boot/camel/pom.xml
@@ -47,6 +47,7 @@
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerPrefix}${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
 
+    <fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>true</fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>
     <fabric8.label.component>${project.artifactId}</fabric8.label.component>
     <fabric8.label.container>spring-boot</fabric8.label.container>
     <fabric8.label.group>quickstarts</fabric8.label.group>

--- a/quickstart/spring-boot/webmvc/pom.xml
+++ b/quickstart/spring-boot/webmvc/pom.xml
@@ -50,6 +50,7 @@
     <fabric8.service.port>80</fabric8.service.port>
     <fabric8.service.containerPort>8080</fabric8.service.containerPort>
 
+    <fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>true</fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>
     <fabric8.label.component>${project.artifactId}</fabric8.label.component>
     <fabric8.label.container>spring-boot</fabric8.label.container>
     <fabric8.label.group>quickstarts</fabric8.label.group>

--- a/quickstart/war/camel-servlet/pom.xml
+++ b/quickstart/war/camel-servlet/pom.xml
@@ -54,6 +54,7 @@
     <fabric8.service.port>9101</fabric8.service.port>
     <fabric8.service.containerPort>8080</fabric8.service.containerPort>
 
+    <fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>true</fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>
     <fabric8.label.component>${project.artifactId}</fabric8.label.component>
     <fabric8.label.container>tomcat</fabric8.label.container>
     <fabric8.label.group>quickstarts</fabric8.label.group>

--- a/quickstart/war/cxf-cdi-servlet/pom.xml
+++ b/quickstart/war/cxf-cdi-servlet/pom.xml
@@ -53,6 +53,7 @@
     <fabric8.service.port>9102</fabric8.service.port>
     <fabric8.service.containerPort>8080</fabric8.service.containerPort>
 
+    <fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>true</fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>
     <fabric8.label.component>${project.artifactId}</fabric8.label.component>
     <fabric8.label.container>tomcat</fabric8.label.container>
     <fabric8.label.group>quickstarts</fabric8.label.group>

--- a/quickstart/war/wildfly/pom.xml
+++ b/quickstart/war/wildfly/pom.xml
@@ -50,6 +50,7 @@
     <fabric8.service.port>9101</fabric8.service.port>
     <fabric8.service.containerPort>8080</fabric8.service.containerPort>
 
+    <fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>true</fabric8.env.AB_JOLOKIA_AUTH_OPENSHIFT>
     <fabric8.label.component>${project.artifactId}</fabric8.label.component>
     <fabric8.label.container>wildfly</fabric8.label.container>
     <fabric8.label.group>quickstarts</fabric8.label.group>

--- a/sandbox/quickstarts/activemq/pom.xml
+++ b/sandbox/quickstarts/activemq/pom.xml
@@ -45,7 +45,7 @@
     <spring-boot-plugin.version>1.2.7.RELEASE</spring-boot-plugin.version>
 
     <!-- Docker & Fabric8 Configs -->
-    <docker.from>fabric8/s2i-java:1.1.0</docker.from>
+    <docker.from>fabric8/s2i-java:1.1.1</docker.from>
     <fabric8.dockerPrefix>docker.io/</fabric8.dockerPrefix>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerPrefix}${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>

--- a/sandbox/quickstarts/jgroups-greeter/pom.xml
+++ b/sandbox/quickstarts/jgroups-greeter/pom.xml
@@ -40,7 +40,7 @@
     <docker.maven.plugin.version>0.13.6</docker.maven.plugin.version>
 
     <!-- Docker & Fabric8 Configs -->
-    <docker.from>fabric8/s2i-java:1.1.0</docker.from>
+    <docker.from>fabric8/s2i-java:1.1.1</docker.from>
     <fabric8.dockerPrefix>docker.io/</fabric8.dockerPrefix>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerPrefix}${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>

--- a/sandbox/quickstarts/keycloak/pom.xml
+++ b/sandbox/quickstarts/keycloak/pom.xml
@@ -47,7 +47,7 @@
     <keycloak.version>1.1.0.Beta2</keycloak.version>
 
     <!-- Docker & Fabric8 Configs -->
-    <docker.from>fabric8/s2i-java:1.1.0</docker.from>
+    <docker.from>fabric8/s2i-java:1.1.1</docker.from>
     <fabric8.dockerPrefix>docker.io/</fabric8.dockerPrefix>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerPrefix}${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>


### PR DESCRIPTION
- Use new s2i base images 1.1.1
- Introduce env  AB_JOLOKIA_AUTH_OPENSHIFT which will be use in fabric8 deployment descriptors to switch on OpenShift SSL auth for the proxy.