### PR TITLE
OSFUSE-106: Updated cdi-camel-mq dependencies and test package name, …

### DIFF
--- a/archetype-itests/pom.xml
+++ b/archetype-itests/pom.xml
@@ -169,7 +169,6 @@
                   <type>jar</type>
                   <overWrite>false</overWrite>
                 </artifactItem>
-<!--
                 <artifactItem>
                   <groupId>io.fabric8.archetypes</groupId>
                   <artifactId>cdi-camel-mq-archetype</artifactId>
@@ -177,7 +176,6 @@
                   <type>jar</type>
                   <overWrite>false</overWrite>
                 </artifactItem>
--->
                 <artifactItem>
                   <groupId>io.fabric8.archetypes</groupId>
                   <artifactId>cdi-cxf-archetype</artifactId>

--- a/quickstart/cdi/camel-mq/pom.xml
+++ b/quickstart/cdi/camel-mq/pom.xml
@@ -162,6 +162,7 @@
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>fabric8-cdi</artifactId>
+      <version>${fabric8.version}</version>
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>

--- a/quickstart/cdi/camel-mq/src/test/java/io/fabric8/quickstarts/camelcdi/KubernetesIntegrationKT.java
+++ b/quickstart/cdi/camel-mq/src/test/java/io/fabric8/quickstarts/camelcdi/KubernetesIntegrationKT.java
@@ -13,15 +13,17 @@
  * implied.  See the License for the specific language governing
  * permissions and limitations under the License.
  */
-package io.fabric8.tests.integration;
+package io.fabric8.quickstarts.camelcdi;
+
+import javax.inject.Inject;
 
 import io.fabric8.annotations.ServiceName;
 import io.fabric8.arquillian.kubernetes.Session;
 import io.fabric8.cdi.deltaspike.DeltaspikeTestBase;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.quickstarts.camelcdi.mq.ActiveMQConfigurer;
-import io.fabric8.quickstarts.camelcdi.ActiveMQComponentFactory;
+
 import org.apache.activemq.camel.component.ActiveMQComponent;
 import org.assertj.core.api.Condition;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -30,8 +32,6 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import javax.inject.Inject;
 
 import static io.fabric8.kubernetes.assertions.Assertions.assertThat;
 

--- a/quickstart/cdi/camel-mq/src/test/java/io/fabric8/quickstarts/camelcdi/MQCdiKubernetes.java
+++ b/quickstart/cdi/camel-mq/src/test/java/io/fabric8/quickstarts/camelcdi/MQCdiKubernetes.java
@@ -13,11 +13,20 @@
  * implied.  See the License for the specific language governing
  * permissions and limitations under the License.
  */
-package io.fabric8.apps.mq;
+package io.fabric8.quickstarts.camelcdi;
+
+import javax.inject.Inject;
+import javax.jms.Connection;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.jms.TextMessage;
 
 import io.fabric8.annotations.ServiceName;
 import io.fabric8.cdi.deltaspike.DeltaspikeTestBase;
 import io.fabric8.quickstarts.camelcdi.mq.ActiveMQConfigurer;
+
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.command.ActiveMQQueue;
 import org.apache.activemq.command.ActiveMQTextMessage;
@@ -27,14 +36,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import javax.inject.Inject;
-import javax.jms.Connection;
-import javax.jms.Message;
-import javax.jms.MessageConsumer;
-import javax.jms.MessageProducer;
-import javax.jms.Session;
-import javax.jms.TextMessage;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;

--- a/sandbox/apps/fabric8mq-autoscaler/src/test/java/io/fabric8/apps/mq/autoscaler/MQAutoscalerKubernetesTest.java
+++ b/sandbox/apps/fabric8mq-autoscaler/src/test/java/io/fabric8/apps/mq/autoscaler/MQAutoscalerKubernetesTest.java
@@ -14,7 +14,7 @@
  * permissions and limitations under the License.
  */
 
-package io.fabric8.apps.mq.autoscaler;
+package io.fabric8.quickstarts.camelcdi.mq.autoscaler;
 
 import io.fabric8.arquillian.kubernetes.Constants;
 import io.fabric8.arquillian.kubernetes.Session;

--- a/sandbox/apps/fabric8mq-controller/src/test/java/io/fabric8/apps/mq/MQKubernetesTest.java
+++ b/sandbox/apps/fabric8mq-controller/src/test/java/io/fabric8/apps/mq/MQKubernetesTest.java
@@ -14,7 +14,7 @@
  * permissions and limitations under the License.
  */
 
-package io.fabric8.apps.mq;
+package io.fabric8.quickstarts.camelcdi.mq;
 
 import io.fabric8.arquillian.kubernetes.Session;
 import io.fabric8.kubernetes.api.model.Pod;


### PR DESCRIPTION
…fixed itests for cdi and karaf amq archetypes

Conflicts:
	archetype-itests/pom.xml