### PR TITLE
OSFUSE-136: Removed repeated builder image stream definitions from s2…

### DIFF
--- a/quickstart/cdi/camel-http/quickstart-template.json
+++ b/quickstart/cdi/camel-http/quickstart-template.json
@@ -102,28 +102,6 @@
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "s2i-java-rhel-${APP_NAME}",
-        "creationTimestamp": null,
-        "labels": {
-          "component": "${APP_NAME}",
-          "container": "java",
-          "group": "quickstarts",
-          "project": "${APP_NAME}",
-          "provider": "s2i",
-          "version": "${APP_VERSION}"
-        }
-      },
-      "spec": {
-        "dockerImageRepository": "fabric8/s2i-java-rhel:${BUILDER_VERSION}"
-      },
-      "status": {
-        "dockerImageRepository": ""
-      }
-    },
-    {
-      "kind": "ImageStream",
-      "apiVersion": "v1",
-      "metadata": {
         "name": "${APP_NAME}",
         "creationTimestamp": null,
         "labels": {
@@ -189,7 +167,8 @@
           "sourceStrategy": {
             "from": {
               "kind": "ImageStreamTag",
-              "name": "s2i-java-rhel-${APP_NAME}:${BUILDER_VERSION}"
+              "namespace": "openshift",
+              "name": "fis-java-openshift:${BUILDER_VERSION}"
             },
             "forcePull": true,
             "env": [

--- a/quickstart/cdi/camel-jetty/quickstart-template.json
+++ b/quickstart/cdi/camel-jetty/quickstart-template.json
@@ -123,28 +123,6 @@
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "s2i-java-rhel-${APP_NAME}",
-        "creationTimestamp": null,
-        "labels": {
-          "component": "${APP_NAME}",
-          "container": "java",
-          "group": "quickstarts",
-          "project": "${APP_NAME}",
-          "provider": "s2i",
-          "version": "${APP_VERSION}"
-        }
-      },
-      "spec": {
-        "dockerImageRepository": "fabric8/s2i-java-rhel:${BUILDER_VERSION}"
-      },
-      "status": {
-        "dockerImageRepository": ""
-      }
-    },
-    {
-      "kind": "ImageStream",
-      "apiVersion": "v1",
-      "metadata": {
         "name": "${APP_NAME}",
         "creationTimestamp": null,
         "labels": {
@@ -210,7 +188,8 @@
           "sourceStrategy": {
             "from": {
               "kind": "ImageStreamTag",
-              "name": "s2i-java-rhel-${APP_NAME}:${BUILDER_VERSION}"
+              "namespace": "openshift",
+              "name": "fis-java-openshift:${BUILDER_VERSION}"
             },
             "forcePull": true,
             "env": [

--- a/quickstart/cdi/camel-mq/quickstart-template.json
+++ b/quickstart/cdi/camel-mq/quickstart-template.json
@@ -101,28 +101,6 @@
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "s2i-java-rhel-${APP_NAME}",
-        "creationTimestamp": null,
-        "labels": {
-          "component": "${APP_NAME}",
-          "container": "java",
-          "group": "quickstarts",
-          "project": "${APP_NAME}",
-          "provider": "s2i",
-          "version": "${APP_VERSION}"
-        }
-      },
-      "spec": {
-        "dockerImageRepository": "fabric8/s2i-java-rhel:${BUILDER_VERSION}"
-      },
-      "status": {
-        "dockerImageRepository": ""
-      }
-    },
-    {
-      "kind": "ImageStream",
-      "apiVersion": "v1",
-      "metadata": {
         "name": "${APP_NAME}",
         "creationTimestamp": null,
         "labels": {
@@ -188,7 +166,8 @@
           "sourceStrategy": {
             "from": {
               "kind": "ImageStreamTag",
-              "name": "s2i-java-rhel-${APP_NAME}:${BUILDER_VERSION}"
+              "namespace": "openshift",
+              "name": "fis-java-openshift:${BUILDER_VERSION}"
             },
             "forcePull": true,
             "env": [

--- a/quickstart/cdi/camel/quickstart-template.json
+++ b/quickstart/cdi/camel/quickstart-template.json
@@ -101,28 +101,6 @@
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "s2i-java-rhel-${APP_NAME}",
-        "creationTimestamp": null,
-        "labels": {
-          "component": "${APP_NAME}",
-          "container": "java",
-          "group": "quickstarts",
-          "project": "${APP_NAME}",
-          "provider": "s2i",
-          "version": "${APP_VERSION}"
-        }
-      },
-      "spec": {
-        "dockerImageRepository": "fabric8/s2i-java-rhel:${BUILDER_VERSION}"
-      },
-      "status": {
-        "dockerImageRepository": ""
-      }
-    },
-    {
-      "kind": "ImageStream",
-      "apiVersion": "v1",
-      "metadata": {
         "name": "${APP_NAME}",
         "creationTimestamp": null,
         "labels": {
@@ -188,7 +166,8 @@
           "sourceStrategy": {
             "from": {
               "kind": "ImageStreamTag",
-              "name": "s2i-java-rhel-${APP_NAME}:${BUILDER_VERSION}"
+              "namespace": "openshift",
+              "name": "fis-java-openshift:${BUILDER_VERSION}"
             },
             "forcePull": true,
             "env": [

--- a/quickstart/cdi/cxf/quickstart-template.json
+++ b/quickstart/cdi/cxf/quickstart-template.json
@@ -128,28 +128,6 @@
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "s2i-java-rhel-${APP_NAME}",
-        "creationTimestamp": null,
-        "labels": {
-          "component": "${APP_NAME}",
-          "container": "java",
-          "group": "quickstarts",
-          "project": "${APP_NAME}",
-          "provider": "s2i",
-          "version": "${APP_VERSION}"
-        }
-      },
-      "spec": {
-        "dockerImageRepository": "fabric8/s2i-java-rhel:${BUILDER_VERSION}"
-      },
-      "status": {
-        "dockerImageRepository": ""
-      }
-    },
-    {
-      "kind": "ImageStream",
-      "apiVersion": "v1",
-      "metadata": {
         "name": "${APP_NAME}",
         "creationTimestamp": null,
         "labels": {
@@ -215,7 +193,8 @@
           "sourceStrategy": {
             "from": {
               "kind": "ImageStreamTag",
-              "name": "s2i-java-rhel-${APP_NAME}:${BUILDER_VERSION}"
+              "namespace": "openshift",
+              "name": "fis-java-openshift:${BUILDER_VERSION}"
             },
             "forcePull": true,
             "env": [

--- a/quickstart/java/camel-spring/quickstart-template.json
+++ b/quickstart/java/camel-spring/quickstart-template.json
@@ -101,28 +101,6 @@
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "s2i-java-rhel-${APP_NAME}",
-        "creationTimestamp": null,
-        "labels": {
-          "component": "${APP_NAME}",
-          "container": "java",
-          "group": "quickstarts",
-          "project": "${APP_NAME}",
-          "provider": "s2i",
-          "version": "${APP_VERSION}"
-        }
-      },
-      "spec": {
-        "dockerImageRepository": "fabric8/s2i-java-rhel:${BUILDER_VERSION}"
-      },
-      "status": {
-        "dockerImageRepository": ""
-      }
-    },
-    {
-      "kind": "ImageStream",
-      "apiVersion": "v1",
-      "metadata": {
         "name": "${APP_NAME}",
         "creationTimestamp": null,
         "labels": {
@@ -188,7 +166,8 @@
           "sourceStrategy": {
             "from": {
               "kind": "ImageStreamTag",
-              "name": "s2i-java-rhel-${APP_NAME}:${BUILDER_VERSION}"
+              "namespace": "openshift",
+              "name": "fis-java-openshift:${BUILDER_VERSION}"
             },
             "forcePull": true,
             "env": [

--- a/quickstart/java/simple-fatjar/quickstart-template.json
+++ b/quickstart/java/simple-fatjar/quickstart-template.json
@@ -66,28 +66,6 @@
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "s2i-java-rhel-${APP_NAME}",
-        "creationTimestamp": null,
-        "labels": {
-          "component": "${APP_NAME}",
-          "container": "java",
-          "group": "quickstarts",
-          "project": "${APP_NAME}",
-          "provider": "s2i",
-          "version": "${APP_VERSION}"
-        }
-      },
-      "spec": {
-        "dockerImageRepository": "fabric8/s2i-java-rhel:${BUILDER_VERSION}"
-      },
-      "status": {
-        "dockerImageRepository": ""
-      }
-    },
-    {
-      "kind": "ImageStream",
-      "apiVersion": "v1",
-      "metadata": {
         "name": "${APP_NAME}",
         "creationTimestamp": null,
         "labels": {
@@ -153,7 +131,8 @@
           "sourceStrategy": {
             "from": {
               "kind": "ImageStreamTag",
-              "name": "s2i-java-rhel-${APP_NAME}:${BUILDER_VERSION}"
+              "namespace": "openshift",
+              "name": "fis-java-openshift:${BUILDER_VERSION}"
             },
             "forcePull": true,
             "env": [

--- a/quickstart/java/simple-mainclass/quickstart-template.json
+++ b/quickstart/java/simple-mainclass/quickstart-template.json
@@ -66,28 +66,6 @@
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "s2i-java-rhel-${APP_NAME}",
-        "creationTimestamp": null,
-        "labels": {
-          "component": "${APP_NAME}",
-          "container": "java",
-          "group": "quickstarts",
-          "project": "${APP_NAME}",
-          "provider": "s2i",
-          "version": "${APP_VERSION}"
-        }
-      },
-      "spec": {
-        "dockerImageRepository": "fabric8/s2i-java-rhel:${BUILDER_VERSION}"
-      },
-      "status": {
-        "dockerImageRepository": ""
-      }
-    },
-    {
-      "kind": "ImageStream",
-      "apiVersion": "v1",
-      "metadata": {
         "name": "${APP_NAME}",
         "creationTimestamp": null,
         "labels": {
@@ -153,7 +131,8 @@
           "sourceStrategy": {
             "from": {
               "kind": "ImageStreamTag",
-              "name": "s2i-java-rhel-${APP_NAME}:${BUILDER_VERSION}"
+              "namespace": "openshift",
+              "name": "fis-java-openshift:${BUILDER_VERSION}"
             },
             "forcePull": true,
             "env": [

--- a/quickstart/karaf/camel-amq/quickstart-template.json
+++ b/quickstart/karaf/camel-amq/quickstart-template.json
@@ -66,28 +66,6 @@
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "s2i-karaf-rhel-${APP_NAME}",
-        "creationTimestamp": null,
-        "labels": {
-          "component": "${APP_NAME}",
-          "container": "karaf",
-          "group": "quickstarts",
-          "project": "${APP_NAME}",
-          "provider": "s2i",
-          "version": "${APP_VERSION}"
-        }
-      },
-      "spec": {
-        "dockerImageRepository": "fabric8/s2i-karaf-rhel:${BUILDER_VERSION}"
-      },
-      "status": {
-        "dockerImageRepository": ""
-      }
-    },
-    {
-      "kind": "ImageStream",
-      "apiVersion": "v1",
-      "metadata": {
         "name": "${APP_NAME}",
         "creationTimestamp": null,
         "labels": {
@@ -153,7 +131,8 @@
           "sourceStrategy": {
             "from": {
               "kind": "ImageStreamTag",
-              "name": "s2i-karaf-rhel-${APP_NAME}:${BUILDER_VERSION}"
+              "namespace": "openshift",
+              "name": "fis-karaf-openshift:${BUILDER_VERSION}"
             },
             "forcePull": true,
             "env": [

--- a/quickstart/karaf/camel-log/quickstart-template.json
+++ b/quickstart/karaf/camel-log/quickstart-template.json
@@ -66,28 +66,6 @@
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "s2i-karaf-rhel-${APP_NAME}",
-        "creationTimestamp": null,
-        "labels": {
-          "component": "${APP_NAME}",
-          "container": "karaf",
-          "group": "quickstarts",
-          "project": "${APP_NAME}",
-          "provider": "s2i",
-          "version": "${APP_VERSION}"
-        }
-      },
-      "spec": {
-        "dockerImageRepository": "fabric8/s2i-karaf-rhel:${BUILDER_VERSION}"
-      },
-      "status": {
-        "dockerImageRepository": ""
-      }
-    },
-    {
-      "kind": "ImageStream",
-      "apiVersion": "v1",
-      "metadata": {
         "name": "${APP_NAME}",
         "creationTimestamp": null,
         "labels": {
@@ -153,7 +131,8 @@
           "sourceStrategy": {
             "from": {
               "kind": "ImageStreamTag",
-              "name": "s2i-karaf-rhel-${APP_NAME}:${BUILDER_VERSION}"
+              "namespace": "openshift",
+              "name": "fis-karaf-openshift:${BUILDER_VERSION}"
             },
             "forcePull": true,
             "env": [

--- a/quickstart/karaf/camel-rest-sql/quickstart-template.json
+++ b/quickstart/karaf/camel-rest-sql/quickstart-template.json
@@ -101,28 +101,6 @@
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "s2i-karaf-rhel-${APP_NAME}",
-        "creationTimestamp": null,
-        "labels": {
-          "component": "${APP_NAME}",
-          "container": "karaf",
-          "group": "quickstarts",
-          "project": "${APP_NAME}",
-          "provider": "s2i",
-          "version": "${APP_VERSION}"
-        }
-      },
-      "spec": {
-        "dockerImageRepository": "fabric8/s2i-karaf-rhel:${BUILDER_VERSION}"
-      },
-      "status": {
-        "dockerImageRepository": ""
-      }
-    },
-    {
-      "kind": "ImageStream",
-      "apiVersion": "v1",
-      "metadata": {
         "name": "${APP_NAME}",
         "creationTimestamp": null,
         "labels": {
@@ -188,7 +166,8 @@
           "sourceStrategy": {
             "from": {
               "kind": "ImageStreamTag",
-              "name": "s2i-karaf-rhel-${APP_NAME}:${BUILDER_VERSION}"
+              "namespace": "openshift",
+              "name": "fis-karaf-openshift:${BUILDER_VERSION}"
             },
             "forcePull": true,
             "env": [

--- a/quickstart/karaf/cxf-rest/quickstart-template.json
+++ b/quickstart/karaf/cxf-rest/quickstart-template.json
@@ -122,28 +122,6 @@
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "s2i-karaf-rhel-${APP_NAME}",
-        "creationTimestamp": null,
-        "labels": {
-          "component": "${APP_NAME}",
-          "container": "karaf",
-          "group": "quickstarts",
-          "project": "${APP_NAME}",
-          "provider": "s2i",
-          "version": "${APP_VERSION}"
-        }
-      },
-      "spec": {
-        "dockerImageRepository": "fabric8/s2i-karaf-rhel:${BUILDER_VERSION}"
-      },
-      "status": {
-        "dockerImageRepository": ""
-      }
-    },
-    {
-      "kind": "ImageStream",
-      "apiVersion": "v1",
-      "metadata": {
         "name": "${APP_NAME}",
         "creationTimestamp": null,
         "labels": {
@@ -209,7 +187,8 @@
           "sourceStrategy": {
             "from": {
               "kind": "ImageStreamTag",
-              "name": "s2i-karaf-rhel-${APP_NAME}:${BUILDER_VERSION}"
+              "namespace": "openshift",
+              "name": "fis-karaf-openshift:${BUILDER_VERSION}"
             },
             "forcePull": true,
             "env": [

--- a/quickstart/spring-boot/camel/quickstart-template.json
+++ b/quickstart/spring-boot/camel/quickstart-template.json
@@ -66,28 +66,6 @@
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "s2i-java-rhel-${APP_NAME}",
-        "creationTimestamp": null,
-        "labels": {
-          "component": "${APP_NAME}",
-          "container": "java",
-          "group": "quickstarts",
-          "project": "${APP_NAME}",
-          "provider": "s2i",
-          "version": "${APP_VERSION}"
-        }
-      },
-      "spec": {
-        "dockerImageRepository": "fabric8/s2i-java-rhel:${BUILDER_VERSION}"
-      },
-      "status": {
-        "dockerImageRepository": ""
-      }
-    },
-    {
-      "kind": "ImageStream",
-      "apiVersion": "v1",
-      "metadata": {
         "name": "${APP_NAME}",
         "creationTimestamp": null,
         "labels": {
@@ -153,7 +131,8 @@
           "sourceStrategy": {
             "from": {
               "kind": "ImageStreamTag",
-              "name": "s2i-java-rhel-${APP_NAME}:${BUILDER_VERSION}"
+              "namespace": "openshift",
+              "name": "fis-java-openshift:${BUILDER_VERSION}"
             },
             "forcePull": true,
             "env": [

--- a/quickstart/spring-boot/webmvc/quickstart-template.json
+++ b/quickstart/spring-boot/webmvc/quickstart-template.json
@@ -120,28 +120,6 @@
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "s2i-java-rhel-${APP_NAME}",
-        "creationTimestamp": null,
-        "labels": {
-          "component": "${APP_NAME}",
-          "container": "java",
-          "group": "quickstarts",
-          "project": "${APP_NAME}",
-          "provider": "s2i",
-          "version": "${APP_VERSION}"
-        }
-      },
-      "spec": {
-        "dockerImageRepository": "fabric8/s2i-java-rhel:${BUILDER_VERSION}"
-      },
-      "status": {
-        "dockerImageRepository": ""
-      }
-    },
-    {
-      "kind": "ImageStream",
-      "apiVersion": "v1",
-      "metadata": {
         "name": "${APP_NAME}",
         "creationTimestamp": null,
         "labels": {
@@ -207,7 +185,8 @@
           "sourceStrategy": {
             "from": {
               "kind": "ImageStreamTag",
-              "name": "s2i-java-rhel-${APP_NAME}:${BUILDER_VERSION}"
+              "namespace": "openshift",
+              "name": "fis-java-openshift:${BUILDER_VERSION}"
             },
             "forcePull": true,
             "env": [

--- a/quickstart/war/camel-servlet/quickstart-template.json
+++ b/quickstart/war/camel-servlet/quickstart-template.json
@@ -122,28 +122,6 @@
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "s2i-java-rhel-${APP_NAME}",
-        "creationTimestamp": null,
-        "labels": {
-          "component": "${APP_NAME}",
-          "container": "java",
-          "group": "quickstarts",
-          "project": "${APP_NAME}",
-          "provider": "s2i",
-          "version": "${APP_VERSION}"
-        }
-      },
-      "spec": {
-        "dockerImageRepository": "fabric8/s2i-java-rhel:${BUILDER_VERSION}"
-      },
-      "status": {
-        "dockerImageRepository": ""
-      }
-    },
-    {
-      "kind": "ImageStream",
-      "apiVersion": "v1",
-      "metadata": {
         "name": "${APP_NAME}",
         "creationTimestamp": null,
         "labels": {
@@ -209,7 +187,8 @@
           "sourceStrategy": {
             "from": {
               "kind": "ImageStreamTag",
-              "name": "s2i-java-rhel-${APP_NAME}:${BUILDER_VERSION}"
+              "namespace": "openshift",
+              "name": "fis-java-openshift:${BUILDER_VERSION}"
             },
             "forcePull": true,
             "env": [

--- a/quickstart/war/cxf-cdi-servlet/quickstart-template.json
+++ b/quickstart/war/cxf-cdi-servlet/quickstart-template.json
@@ -209,7 +209,8 @@
           "sourceStrategy": {
             "from": {
               "kind": "ImageStreamTag",
-              "name": "s2i-java-rhel-${APP_NAME}:${BUILDER_VERSION}"
+              "namespace": "openshift",
+              "name": "fis-java-openshift:${BUILDER_VERSION}"
             },
             "forcePull": true,
             "env": [

--- a/quickstart/war/wildfly/quickstart-template.json
+++ b/quickstart/war/wildfly/quickstart-template.json
@@ -209,7 +209,8 @@
           "sourceStrategy": {
             "from": {
               "kind": "ImageStreamTag",
-              "name": "s2i-java-rhel-${APP_NAME}:${BUILDER_VERSION}"
+              "namespace": "openshift",
+              "name": "fis-java-openshift:${BUILDER_VERSION}"
             },
             "forcePull": true,
             "env": [


### PR DESCRIPTION
…i templates, to be moved to xPaas image stream definitions at https://github.com/jboss-openshift/application-templates/blob/master/jboss-image-streams.json