### PR TITLE
Update base images to 1.2

### DIFF
--- a/quickstart/cdi/camel-http/pom.xml
+++ b/quickstart/cdi/camel-http/pom.xml
@@ -48,7 +48,7 @@
     <weld.version>2.3.2.Final</weld.version>
 
     <!-- Docker & Fabric8 Configs -->
-    <docker.from>fabric8/s2i-java:1.2.8</docker.from>
+    <docker.from>fabric8/s2i-java:1.2</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>

--- a/quickstart/cdi/camel-jetty/pom.xml
+++ b/quickstart/cdi/camel-jetty/pom.xml
@@ -48,7 +48,7 @@
     <weld.version>2.3.2.Final</weld.version>
 
     <!-- Docker & Fabric8 Configs -->
-    <docker.from>fabric8/s2i-java:1.2.8</docker.from>
+    <docker.from>fabric8/s2i-java:1.2</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>

--- a/quickstart/cdi/camel-mq/pom.xml
+++ b/quickstart/cdi/camel-mq/pom.xml
@@ -49,7 +49,7 @@
     <weld.version>2.3.2.Final</weld.version>
 
     <!-- Docker & Fabric8 Configs -->
-    <docker.from>fabric8/s2i-java:1.2.8</docker.from>
+    <docker.from>fabric8/s2i-java:1.2</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>

--- a/quickstart/cdi/camel/pom.xml
+++ b/quickstart/cdi/camel/pom.xml
@@ -47,7 +47,7 @@
     <weld.version>2.3.2.Final</weld.version>
 
     <!-- Docker & Fabric8 Configs -->
-    <docker.from>fabric8/s2i-java:1.2.8</docker.from>
+    <docker.from>fabric8/s2i-java:1.2</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>

--- a/quickstart/cdi/cxf/pom.xml
+++ b/quickstart/cdi/cxf/pom.xml
@@ -52,7 +52,7 @@
     <http.port>9092</http.port>
 
     <!-- Docker & Fabric8 Configs -->
-    <docker.from>fabric8/s2i-java:1.2.8</docker.from>
+    <docker.from>fabric8/s2i-java:1.2</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
     <docker.port.container.http>${http.port}</docker.port.container.http>

--- a/quickstart/java/camel-spring/pom.xml
+++ b/quickstart/java/camel-spring/pom.xml
@@ -46,7 +46,7 @@
     <camel.version>2.16.1</camel.version>
 
     <!-- Docker & Fabric8 Configs -->
-    <docker.from>fabric8/s2i-java:1.2.8</docker.from>
+    <docker.from>fabric8/s2i-java:1.2</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>

--- a/quickstart/java/simple-mainclass/pom.xml
+++ b/quickstart/java/simple-mainclass/pom.xml
@@ -42,7 +42,7 @@
     <docker.maven.plugin.version>0.13.6</docker.maven.plugin.version>
 
     <!-- Docker & Fabric8 Configs -->
-    <docker.from>fabric8/s2i-java:1.2.8</docker.from>
+    <docker.from>fabric8/s2i-java:1.2</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>

--- a/quickstart/karaf/camel-amq/pom.xml
+++ b/quickstart/karaf/camel-amq/pom.xml
@@ -48,7 +48,7 @@
     <karaf.version>2.4.3</karaf.version>
     <karaf.plugin.version>4.0.3</karaf.plugin.version>
 
-    <docker.from>fabric8/s2i-karaf:1.2.8</docker.from>
+    <docker.from>fabric8/s2i-karaf:1.2</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
     <docker.assemblyDescriptor>${basedir}/src/main/fabric8/assembly.xml</docker.assemblyDescriptor>

--- a/quickstart/karaf/camel-log/pom.xml
+++ b/quickstart/karaf/camel-log/pom.xml
@@ -48,7 +48,7 @@
     <karaf.version>2.4.3</karaf.version>
     <karaf.plugin.version>4.0.3</karaf.plugin.version>
 
-    <docker.from>fabric8/s2i-karaf:1.2.8</docker.from>
+    <docker.from>fabric8/s2i-karaf:1.2</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerUser}quickstart-karaf-camellog:${project.version}</docker.image>
     <docker.assemblyDescriptor>${basedir}/src/main/fabric8/assembly.xml</docker.assemblyDescriptor>

--- a/quickstart/karaf/camel-rest-sql/pom.xml
+++ b/quickstart/karaf/camel-rest-sql/pom.xml
@@ -50,7 +50,7 @@
     <spring.features.version>3.0.4</spring.features.version>
     <spring.tx.feature.version>3.2.11.RELEASE_1</spring.tx.feature.version>
 
-    <docker.from>fabric8/s2i-karaf:1.2.8</docker.from>
+    <docker.from>fabric8/s2i-karaf:1.2</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerUser}quickstart-karaf-camelrest:${project.version}</docker.image>
     <docker.assemblyDescriptor>${basedir}/src/main/fabric8/assembly.xml</docker.assemblyDescriptor>

--- a/quickstart/karaf/cxf-rest/pom.xml
+++ b/quickstart/karaf/cxf-rest/pom.xml
@@ -46,7 +46,7 @@
     <karaf.version>2.4.3</karaf.version>
     <karaf.plugin.version>4.0.3</karaf.plugin.version>
 
-    <docker.from>fabric8/s2i-karaf:1.2.8</docker.from>
+    <docker.from>fabric8/s2i-karaf:1.2</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
     <docker.assemblyDescriptor>${basedir}/src/main/fabric8/assembly.xml</docker.assemblyDescriptor>

--- a/sandbox/quickstarts/activemq/pom.xml
+++ b/sandbox/quickstarts/activemq/pom.xml
@@ -45,7 +45,7 @@
     <spring-boot-plugin.version>1.2.7.RELEASE</spring-boot-plugin.version>
 
     <!-- Docker & Fabric8 Configs -->
-    <docker.from>fabric8/s2i-java:1.2.8</docker.from>
+    <docker.from>fabric8/s2i-java:1.2</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
 

--- a/sandbox/quickstarts/jgroups-greeter/pom.xml
+++ b/sandbox/quickstarts/jgroups-greeter/pom.xml
@@ -40,7 +40,7 @@
     <docker.maven.plugin.version>0.13.6</docker.maven.plugin.version>
 
     <!-- Docker & Fabric8 Configs -->
-    <docker.from>fabric8/s2i-java:1.2.8</docker.from>
+    <docker.from>fabric8/s2i-java:1.2</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
     <jgroups.port>7800</jgroups.port>

--- a/sandbox/quickstarts/keycloak/pom.xml
+++ b/sandbox/quickstarts/keycloak/pom.xml
@@ -47,7 +47,7 @@
     <keycloak.version>1.1.0.Beta2</keycloak.version>
 
     <!-- Docker & Fabric8 Configs -->
-    <docker.from>fabric8/s2i-java:1.2.8</docker.from>
+    <docker.from>fabric8/s2i-java:1.2</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
 


### PR DESCRIPTION
So that its more stable on the patch level. 1.2 will alway point to the latest patch.