### PR TITLE
More work on Vert.x quickstarts

### DIFF
--- a/quickstart/pom.xml
+++ b/quickstart/pom.xml
@@ -53,6 +53,7 @@
     <module>cdi</module>
     <module>spring-boot</module>
     <module>war</module>
+    <module>vertx</module>
   </modules>
 
   <developers>

--- a/quickstart/vertx/README.md
+++ b/quickstart/vertx/README.md
@@ -5,6 +5,8 @@ Various quickstart projects using [Vert.x](http://vertx.io/).
 The following quickstarts is provided out of the box:
 
 * [simplest](simplest) - The simplest possible fat jar Vert.x quickstart
+* [chat](chat) - A simple clustered chat example. View the chat webapp in multiple browsers (use multiple to make sure
+you have multiple browser connections). Increase number of replicas and verify chat continues to work.
 * [eventbus](eventbus) - A simple clustered event bus example. Increase the number of replicas and watch the logs to see
 the different pod instances sending and receiving messages on the event bus.
 

--- a/quickstart/vertx/README.md
+++ b/quickstart/vertx/README.md
@@ -5,4 +5,6 @@ Various quickstart projects using [Vert.x](http://vertx.io/).
 The following quickstarts is provided out of the box:
 
 * [simplest](simplest) - The simplest possible fat jar Vert.x quickstart
+* [eventbus](eventbus) - A simple clustered event bus example. Increase the number of replicas and watch the logs to see
+the different pod instances sending and receiving messages on the event bus.
 

--- a/quickstart/vertx/chat/pom.xml
+++ b/quickstart/vertx/chat/pom.xml
@@ -27,18 +27,18 @@
     <version>2.2.91-SNAPSHOT</version>
   </parent>
 
-  <artifactId>vertx-simplest</artifactId>
+  <artifactId>vertx-chat</artifactId>
   <version>2.2.91-SNAPSHOT</version>
   <packaging>jar</packaging>
 
-  <name>Fabric8 :: Quickstarts :: Vert.x :: Simplest fat jar</name>
-  <description>Simple embedded vert.x fatjar</description>
+  <name>Fabric8 :: Quickstarts :: Vert.x :: Chat</name>
+  <description>Vert.x clustered chat example</description>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- fabric8 version -->
-    <fabric8.version>2.2.84</fabric8.version>
+    <fabric8.version>2.2.85-SNAPSHOT</fabric8.version>
     <docker.maven.plugin.version>0.13.6</docker.maven.plugin.version>
 
     <!-- Docker & Fabric8 Configs -->
@@ -51,14 +51,24 @@
     <fabric8.label.group>quickstarts</fabric8.label.group>
     <fabric8.iconRef>vertx</fabric8.iconRef>
 
+    <!--
+    We create two services
+    1. A loadbalancing service for the web traffic to the application
+    2. A headless service so different containers can discover each other as Hazelcast nodes
+    This is pretty typical for Vert.x microservices which often act as both webserver and hazelcast node
+    -->
 
-    <fabric8.service.name>${project.artifactId}</fabric8.service.name>
-    <fabric8.service.port>80</fabric8.service.port>
-    <fabric8.service.containerPort>8080</fabric8.service.containerPort>
-    <fabric8.service.type>LoadBalancer</fabric8.service.type>
+    <fabric8.service.vertx-chat.port>80</fabric8.service.vertx-chat.port>
+    <fabric8.service.vertx-chat.containerPort>8080</fabric8.service.vertx-chat.containerPort>
+    <fabric8.service.vertx-chat.type>LoadBalancer</fabric8.service.vertx-chat.type>
+
+    <fabric8.service.vertx-chat-hz.headless>true</fabric8.service.vertx-chat-hz.headless>
+    <fabric8.service.vertx-chat-hz.port>5701</fabric8.service.vertx-chat-hz.port>
+    <fabric8.service.vertx-chat-hz.containerPort>5701</fabric8.service.vertx-chat-hz.containerPort>
+
 
     <!-- the main class -->
-    <exec.mainClass>io.fabric8.quickstarts.vertxsimplest.HelloWorldEmbedded</exec.mainClass>
+    <exec.mainClass>io.fabric8.quickstarts.vertxchat.ChatServer</exec.mainClass>
 
   </properties>
 
@@ -79,6 +89,21 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
       <version>3.2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web</artifactId>
+      <version>3.2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-hazelcast</artifactId>
+      <version>3.3.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>com.noctarius.discovery</groupId>
+      <artifactId>hazelcast-kubernetes-discovery</artifactId>
+      <version>0.9.2-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/quickstart/vertx/chat/src/main/java/io/fabric8/quickstarts/vertxchat/ChatServer.java
+++ b/quickstart/vertx/chat/src/main/java/io/fabric8/quickstarts/vertxchat/ChatServer.java
@@ -1,0 +1,61 @@
+package io.fabric8.quickstarts.vertxchat;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Launcher;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.handler.StaticHandler;
+import io.vertx.ext.web.handler.sockjs.BridgeOptions;
+import io.vertx.ext.web.handler.sockjs.PermittedOptions;
+import io.vertx.ext.web.handler.sockjs.SockJSHandler;
+
+import java.text.DateFormat;
+import java.time.Instant;
+import java.util.Date;
+
+/**
+ * A {@link io.vertx.core.Verticle} which implements a simple, realtime,
+ * multiuser chat. Anyone can connect to the chat application on port
+ * 8000 and type messages. The messages will be rebroadcast to all
+ * connected users via the @{link EventBus} Websocket bridge.
+ *
+ * @author <a href="https://github.com/InfoSec812">Deven Phillips</a>
+ */
+public class ChatServer extends AbstractVerticle {
+
+  public static void main(String[] args) {
+    Launcher.main(new String[]{"run", ChatServer.class.getName(), "-cluster"});
+  }
+
+  @Override
+  public void start() throws Exception {
+
+    Router router = Router.router(vertx);
+
+    // Allow events for the designated addresses in/out of the event bus bridge
+    BridgeOptions opts = new BridgeOptions()
+      .addInboundPermitted(new PermittedOptions().setAddress("chat.to.server"))
+      .addOutboundPermitted(new PermittedOptions().setAddress("chat.to.client"));
+
+    // Create the event bus bridge and add it to the router.
+    SockJSHandler ebHandler = SockJSHandler.create(vertx).bridge(opts);
+    router.route("/eventbus/*").handler(ebHandler);
+
+    // Create a router endpoint for the static content.
+    router.route().handler(StaticHandler.create());
+
+    // Start the web server and tell it to use the router to handle requests.
+    vertx.createHttpServer().requestHandler(router::accept).listen(8080);
+
+    EventBus eb = vertx.eventBus();
+
+    // Register to listen for messages coming IN to the server
+    eb.consumer("chat.to.server").handler(message -> {
+      // Create a timestamp string
+      String timestamp = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM).format(Date.from(Instant.now()));
+      // Send the message back out to all clients with the timestamp prepended.
+      eb.publish("chat.to.client", ChatServer.this + ":" + timestamp + ": " + message.body());
+    });
+
+  }
+}

--- a/quickstart/vertx/chat/src/main/resources/cluster.xml
+++ b/quickstart/vertx/chat/src/main/resources/cluster.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.6.xsd"
+           xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <properties>
+    <property name="hazelcast.mancenter.enabled">false</property>
+    <property name="hazelcast.memcache.enabled">false</property>
+    <property name="hazelcast.rest.enabled">false</property>
+    <property name="hazelcast.wait.seconds.before.join">0</property>
+    <property name="hazelcast.logging.type">jdk</property>
+
+    <!-- at the moment the discovery needs to be activated explicitly -->
+    <property name="hazelcast.discovery.enabled">true</property>
+
+  </properties>
+
+  <group>
+    <name>dev</name>
+    <password>dev-pass</password>
+  </group>
+  <management-center enabled="false">http://localhost:8080/mancenter</management-center>
+  <network>
+    <port auto-increment="true" port-count="10000">5701</port>
+    <outbound-ports>
+      <!--
+      Allowed port range when connecting to other nodes.
+      0 or * means use system provided port.
+      -->
+      <ports>0</ports>
+    </outbound-ports>
+    <join>
+      <multicast enabled="false"/>
+
+      <tcp-ip enabled="false"/>
+      <discovery-strategies>
+        <discovery-strategy enabled="true"
+                                class="com.noctarius.hazelcast.kubernetes.HazelcastKubernetesDiscoveryStrategy">
+          <properties>
+            <!-- configure discovery headless service  lookup -->
+            <property name="service-dns">vertx-eventbus-hz</property>
+          </properties>
+        </discovery-strategy>
+      </discovery-strategies>
+    </join>
+
+    <interfaces enabled="false">
+      <interface>10.10.1.*</interface>
+    </interfaces>
+    <ssl enabled="false"/>
+    <socket-interceptor enabled="false"/>
+    <symmetric-encryption enabled="false">
+      <!--
+         encryption algorithm such as
+         DES/ECB/PKCS5Padding,
+         PBEWithMD5AndDES,
+         AES/CBC/PKCS5Padding,
+         Blowfish,
+         DESede
+      -->
+      <algorithm>PBEWithMD5AndDES</algorithm>
+      <!-- salt value to use when generating the secret key -->
+      <salt>thesalt</salt>
+      <!-- pass phrase to use when generating the secret key -->
+      <password>thepass</password>
+      <!-- iteration count to use when generating the secret key -->
+      <iteration-count>19</iteration-count>
+    </symmetric-encryption>
+  </network>
+  <partition-group enabled="false"/>
+  <executor-service name="default">
+    <pool-size>16</pool-size>
+    <!--Queue capacity. 0 means Integer.MAX_VALUE.-->
+    <queue-capacity>0</queue-capacity>
+  </executor-service>
+  <map name="__vertx.subs">
+
+    <!--
+        Number of backups. If 1 is set as the backup-count for example,
+        then all entries of the map will be copied to another JVM for
+        fail-safety. 0 means no backup.
+    -->
+    <backup-count>1</backup-count>
+    <!--
+  Maximum number of seconds for each entry to stay in the map. Entries that are
+  older than <time-to-live-seconds> and not updated for <time-to-live-seconds>
+  will get automatically evicted from the map.
+  Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+-->
+    <time-to-live-seconds>0</time-to-live-seconds>
+    <!--
+  Maximum number of seconds for each entry to stay idle in the map. Entries that are
+  idle(not touched) for more than <max-idle-seconds> will get
+  automatically evicted from the map. Entry is touched if get, put or containsKey is called.
+  Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+-->
+    <max-idle-seconds>0</max-idle-seconds>
+    <!--
+        Valid values are:
+        NONE (no eviction),
+        LRU (Least Recently Used),
+        LFU (Least Frequently Used).
+        NONE is the default.
+    -->
+    <eviction-policy>NONE</eviction-policy>
+    <!--
+        Maximum size of the map. When max size is reached,
+        map is evicted based on the policy defined.
+        Any integer between 0 and Integer.MAX_VALUE. 0 means
+        Integer.MAX_VALUE. Default is 0.
+    -->
+    <max-size policy="PER_NODE">0</max-size>
+    <!--
+        When max. size is reached, specified percentage of
+        the map will be evicted. Any integer between 0 and 100.
+        If 25 is set for example, 25% of the entries will
+        get evicted.
+    -->
+    <eviction-percentage>25</eviction-percentage>
+    <!--
+        While recovering from split-brain (network partitioning),
+        map entries in the small cluster will merge into the bigger cluster
+        based on the policy set here. When an entry merge into the
+        cluster, there might an existing entry with the same key already.
+        Values of these entries might be different for that same key.
+        Which value should be set for the key? Conflict is resolved by
+        the policy set here. Default policy is PutIfAbsentMapMergePolicy
+
+        There are built-in merge policies such as
+        com.hazelcast.map.merge.PassThroughMergePolicy; entry will be added if there is no existing entry for the key.
+        com.hazelcast.map.merge.PutIfAbsentMapMergePolicy ; entry will be added if the merging entry doesn't exist in the cluster.
+        com.hazelcast.map.merge.HigherHitsMapMergePolicy ; entry with the higher hits wins.
+        com.hazelcast.map.merge.LatestUpdateMapMergePolicy ; entry with the latest update wins.
+    -->
+    <merge-policy>com.hazelcast.map.merge.LatestUpdateMapMergePolicy</merge-policy>
+
+  </map>
+
+  <!-- Used internally in Vert.x to implement async locks -->
+  <semaphore name="__vertx.*">
+    <initial-permits>1</initial-permits>
+  </semaphore>
+
+</hazelcast>

--- a/quickstart/vertx/chat/src/main/resources/webroot/index.html
+++ b/quickstart/vertx/chat/src/main/resources/webroot/index.html
@@ -1,0 +1,70 @@
+<!--
+  #%L
+  distributed-chat-service
+  %%
+  Copyright (C) 2015 Zanclus Consulting
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+<html>
+<head>
+  <title>Distributed Chat Service</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script src="https://code.jquery.com/jquery-1.11.2.min.js"></script>
+  <script src="//cdn.jsdelivr.net/sockjs/0.3.4/sockjs.min.js"></script>
+  <script src="vertx-eventbus.js"></script>
+  <style>
+    .inset {
+      box-shadow: inset 0 0 4px #000000;
+      -moz-box-shadow: inset 0 0 4px #000000;
+      -webkit-box-shadow: inset 0 0 4px #000000;
+      width: 400px;
+      border-width: 4px;
+      padding: 5px;
+    }
+
+    input.inset {
+      height: 40px;
+    }
+
+    div.inset {
+      height: 500px;
+      white-space: pre-wrap
+    }
+  </style>
+</head>
+<body>
+<script>
+  var eb = new EventBus("/eventbus/");
+  eb.onopen = function () {
+    eb.registerHandler("chat.to.client", function (err, msg) {
+      $('#chat').append(msg.body + "\n");
+    });
+  };
+
+  function send(event) {
+    if (event.keyCode == 13 || event.which == 13) {
+      var message = $('#input').val();
+      if (message.length > 0) {
+        eb.send("chat.to.server", message);
+        $('#input').val("");
+      }
+    }
+  }
+</script>
+<div id="chat" class="inset"></div>
+<input id="input" type="text" onkeydown="send(event)" class="inset">
+</body>
+</html>

--- a/quickstart/vertx/chat/src/main/resources/webroot/vertx-eventbus.js
+++ b/quickstart/vertx/chat/src/main/resources/webroot/vertx-eventbus.js
@@ -1,0 +1,296 @@
+/*
+ *   Copyright (c) 2011-2015 The original author or authors
+ *   ------------------------------------------------------
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ */
+!function (factory) {
+  if (typeof require === 'function' && typeof module !== 'undefined') {
+    // CommonJS loader
+    var SockJS = require('sockjs-client');
+    if(!SockJS) {
+      throw new Error('vertx-eventbus.js requires sockjs-client, see http://sockjs.org');
+    }
+    factory(SockJS);
+  } else if (typeof define === 'function' && define.amd) {
+    // AMD loader
+    define('vertx-eventbus', ['sockjs'], factory);
+  } else {
+    // plain old include
+    if (typeof this.SockJS === 'undefined') {
+      throw new Error('vertx-eventbus.js requires sockjs-client, see http://sockjs.org');
+    }
+
+    EventBus = factory(this.SockJS);
+  }
+}(function (SockJS) {
+
+  function makeUUID() {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (a, b) {
+      return b = Math.random() * 16, (a == 'y' ? b & 3 | 8 : b | 0).toString(16);
+    });
+  }
+
+  function mergeHeaders(defaultHeaders, headers) {
+    if (defaultHeaders) {
+      if(!headers) {
+        return defaultHeaders;
+      }
+
+      for (var headerName in defaultHeaders) {
+        if (defaultHeaders.hasOwnProperty(headerName)) {
+          // user can overwrite the default headers
+          if (typeof headers[headerName] === 'undefined') {
+            headers[headerName] = defaultHeaders[headerName];
+          }
+        }
+      }
+    }
+
+    // headers are required to be a object
+    return headers || {};
+  }
+
+  /**
+   * EventBus
+   *
+   * @param url
+   * @param options
+   * @constructor
+   */
+  var EventBus = function (url, options) {
+    var self = this;
+
+    options = options || {};
+
+    var pingInterval = options.vertxbus_ping_interval || 5000;
+    var pingTimerID;
+
+    // attributes
+    this.sockJSConn = new SockJS(url, null, options);
+    this.state = EventBus.CONNECTING;
+    this.handlers = {};
+    this.replyHandlers = {};
+    this.defaultHeaders = null;
+
+    // default event handlers
+    this.onerror = console.error;
+
+    var sendPing = function () {
+      self.sockJSConn.send(JSON.stringify({type: 'ping'}));
+    };
+
+    this.sockJSConn.onopen = function () {
+      // Send the first ping then send a ping every pingInterval milliseconds
+      sendPing();
+      pingTimerID = setInterval(sendPing, pingInterval);
+      self.state = EventBus.OPEN;
+      self.onopen && self.onopen();
+    };
+
+    this.sockJSConn.onclose = function () {
+      self.state = EventBus.CLOSED;
+      if (pingTimerID) clearInterval(pingTimerID);
+      self.onclose && self.onclose();
+    };
+
+    this.sockJSConn.onmessage = function (e) {
+      var json = JSON.parse(e.data);
+
+      // define a reply function on the message itself
+      if (json.replyAddress) {
+        Object.defineProperty(json, 'reply', {
+          value: function (message, headers, callback) {
+            self.send(json.replyAddress, message, headers, callback);
+          }
+        });
+      }
+
+      if (self.handlers[json.address]) {
+        // iterate all registered handlers
+        var handlers = self.handlers[json.address];
+        for (var i = 0; i < handlers.length; i++) {
+          if (json.type === 'err') {
+            handlers[i]({failureCode: json.failureCode, failureType: json.failureType, message: json.message});
+          } else {
+            handlers[i](null, json);
+          }
+        }
+      } else if (self.replyHandlers[json.address]) {
+        // Might be a reply message
+        var handler = self.replyHandlers[json.address];
+        delete self.replyHandlers[json.address];
+        if (json.type === 'err') {
+          handler({failureCode: json.failureCode, failureType: json.failureType, message: json.message});
+        } else {
+          handler(null, json);
+        }
+      } else {
+        if (json.type === 'err') {
+          self.onerror(json);
+        } else {
+          console.warn('No handler found for message: ', json);
+        }
+      }
+    }
+  };
+
+  /**
+   * Send a message
+   *
+   * @param {String} address
+   * @param {Object} message
+   * @param {Object} [headers]
+   * @param {Function} [callback]
+   */
+  EventBus.prototype.send = function (address, message, headers, callback) {
+    // are we ready?
+    if (this.state != EventBus.OPEN) {
+      throw new Error('INVALID_STATE_ERR');
+    }
+
+    if (typeof headers === 'function') {
+      callback = headers;
+      headers = {};
+    }
+
+    var envelope = {
+      type: 'send',
+      address: address,
+      headers: mergeHeaders(this.defaultHeaders, headers),
+      body: message
+    };
+
+    if (callback) {
+      var replyAddress = makeUUID();
+      envelope.replyAddress = replyAddress;
+      this.replyHandlers[replyAddress] = callback;
+    }
+
+    this.sockJSConn.send(JSON.stringify(envelope));
+  };
+
+  /**
+   * Publish a message
+   *
+   * @param {String} address
+   * @param {Object} message
+   * @param {Object} [headers]
+   */
+  EventBus.prototype.publish = function (address, message, headers) {
+    // are we ready?
+    if (this.state != EventBus.OPEN) {
+      throw new Error('INVALID_STATE_ERR');
+    }
+
+    this.sockJSConn.send(JSON.stringify({
+      type: 'publish',
+      address: address,
+      headers: mergeHeaders(this.defaultHeaders, headers),
+      body: message
+    }));
+  };
+
+  /**
+   * Register a new handler
+   *
+   * @param {String} address
+   * @param {Object} [headers]
+   * @param {Function} callback
+   */
+  EventBus.prototype.registerHandler = function (address, headers, callback) {
+    // are we ready?
+    if (this.state != EventBus.OPEN) {
+      throw new Error('INVALID_STATE_ERR');
+    }
+
+    if (typeof headers === 'function') {
+      callback = headers;
+      headers = {};
+    }
+
+    // ensure it is an array
+    if (!this.handlers[address]) {
+      this.handlers[address] = [];
+      // First handler for this address so we should register the connection
+      this.sockJSConn.send(JSON.stringify({
+        type: 'register',
+        address: address,
+        headers: mergeHeaders(this.defaultHeaders, headers)
+      }));
+    }
+
+    this.handlers[address].push(callback);
+  };
+
+  /**
+   * Unregister a handler
+   *
+   * @param {String} address
+   * @param {Object} [headers]
+   * @param {Function} callback
+   */
+  EventBus.prototype.unregisterHandler = function (address, headers, callback) {
+    // are we ready?
+    if (this.state != EventBus.OPEN) {
+      throw new Error('INVALID_STATE_ERR');
+    }
+
+    var handlers = this.handlers[address];
+
+    if (handlers) {
+
+      if (typeof headers === 'function') {
+        callback = headers;
+        headers = {};
+      }
+
+      var idx = handlers.indexOf(callback);
+      if (idx != -1) {
+        handlers.splice(idx, 1);
+        if (handlers.length === 0) {
+          // No more local handlers so we should unregister the connection
+          this.sockJSConn.send(JSON.stringify({
+            type: 'unregister',
+            address: address,
+            headers: mergeHeaders(this.defaultHeaders, headers)
+          }));
+
+          delete this.handlers[address];
+        }
+      }
+    }
+  };
+
+  /**
+   * Closes the connection to the EvenBus Bridge.
+   */
+  EventBus.prototype.close = function () {
+    this.state = vertx.EventBus.CLOSING;
+    this.sockJSConn.close();
+  };
+
+  EventBus.CONNECTING = 0;
+  EventBus.OPEN = 1;
+  EventBus.CLOSING = 2;
+  EventBus.CLOSED = 3;
+
+  if (typeof exports !== 'undefined') {
+    if (typeof module !== 'undefined' && module.exports) {
+      exports = module.exports = EventBus;
+    } else {
+      exports.EventBus = EventBus;
+    }
+  } else {
+    return EventBus;
+  }
+});

--- a/quickstart/vertx/eventbus/pom.xml
+++ b/quickstart/vertx/eventbus/pom.xml
@@ -89,10 +89,17 @@
       <artifactId>vertx-core</artifactId>
       <version>3.2.0</version>
     </dependency>
+    <!-- We need to override the HZ dependency pulled in by vertx-hazelcast 3.2.0 as we require HZ > 3.6 as the
+    kubernetes discovery stuff is only present in that version or later -->
+    <dependency>
+      <groupId>com.hazelcast</groupId>
+      <artifactId>hazelcast</artifactId>
+      <version>3.6-EA2</version>
+    </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-hazelcast</artifactId>
-      <version>3.3.0-SNAPSHOT</version>
+      <version>3.2.0</version>
     </dependency>
     <dependency>
       <groupId>com.noctarius.discovery</groupId>

--- a/quickstart/vertx/eventbus/pom.xml
+++ b/quickstart/vertx/eventbus/pom.xml
@@ -27,18 +27,18 @@
     <version>2.2.91-SNAPSHOT</version>
   </parent>
 
-  <artifactId>vertx-simplest</artifactId>
+  <artifactId>vertx-eventbus</artifactId>
   <version>2.2.91-SNAPSHOT</version>
   <packaging>jar</packaging>
 
-  <name>Fabric8 :: Quickstarts :: Vert.x :: Simplest fat jar</name>
-  <description>Simple embedded vert.x fatjar</description>
+  <name>Fabric8 :: Quickstarts :: Vert.x :: EventBus</name>
+  <description>Vert.x clustered eventbus example</description>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- fabric8 version -->
-    <fabric8.version>2.2.84</fabric8.version>
+    <fabric8.version>2.2.85-SNAPSHOT</fabric8.version>
     <docker.maven.plugin.version>0.13.6</docker.maven.plugin.version>
 
     <!-- Docker & Fabric8 Configs -->
@@ -51,14 +51,23 @@
     <fabric8.label.group>quickstarts</fabric8.label.group>
     <fabric8.iconRef>vertx</fabric8.iconRef>
 
+    <!--
+    We create two services
+    1. A loadbalancing service for the web traffic to the application
+    2. A headless service so different containers can discover each other as Hazelcast nodes
+    This is pretty typical for Vert.x microservices which often act as both webserver and hazelcast node
+    -->
 
-    <fabric8.service.name>${project.artifactId}</fabric8.service.name>
-    <fabric8.service.port>80</fabric8.service.port>
-    <fabric8.service.containerPort>8080</fabric8.service.containerPort>
-    <fabric8.service.type>LoadBalancer</fabric8.service.type>
+    <fabric8.service.vertx-eventbus.port>80</fabric8.service.vertx-eventbus.port>
+    <fabric8.service.vertx-eventbus.containerPort>8080</fabric8.service.vertx-eventbus.containerPort>
+    <fabric8.service.vertx-eventbus.type>LoadBalancer</fabric8.service.vertx-eventbus.type>
+
+    <fabric8.service.vertx-eventbus-hz.headless>true</fabric8.service.vertx-eventbus-hz.headless>
+    <fabric8.service.vertx-eventbus-hz.port>5701</fabric8.service.vertx-eventbus-hz.port>
+    <fabric8.service.vertx-eventbus-hz.containerPort>5701</fabric8.service.vertx-eventbus-hz.containerPort>
 
     <!-- the main class -->
-    <exec.mainClass>io.fabric8.quickstarts.vertxsimplest.HelloWorldEmbedded</exec.mainClass>
+    <exec.mainClass>io.fabric8.quickstarts.vertxchat.EventBusExample</exec.mainClass>
 
   </properties>
 
@@ -79,6 +88,16 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
       <version>3.2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-hazelcast</artifactId>
+      <version>3.3.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>com.noctarius.discovery</groupId>
+      <artifactId>hazelcast-kubernetes-discovery</artifactId>
+      <version>0.9.2-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/quickstart/vertx/eventbus/src/main/java/io/fabric8/quickstarts/vertxchat/EventBusExample.java
+++ b/quickstart/vertx/eventbus/src/main/java/io/fabric8/quickstarts/vertxchat/EventBusExample.java
@@ -1,0 +1,31 @@
+package io.fabric8.quickstarts.vertxchat;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Launcher;
+import io.vertx.core.eventbus.EventBus;
+
+/**
+ *
+ */
+public class EventBusExample extends AbstractVerticle {
+
+  private static final String HOST_NAME = System.getenv("HOSTNAME");
+
+  public static void main(String[] args) {
+    Launcher.main(new String[]{"run", EventBusExample.class.getName(), "-cluster"});
+  }
+
+  @Override
+  public void start() throws Exception {
+
+    EventBus eb = vertx.eventBus();
+
+    // Register to listen for messages coming IN to the server
+    eb.consumer("example.testeb").handler(message -> {
+      System.out.println(EventBusExample.this + " received an incoming message " + message.body());
+    });
+
+    vertx.setPeriodic(1000, tid -> eb.publish("example.testeb", "Test message from " + HOST_NAME));
+
+  }
+}

--- a/quickstart/vertx/eventbus/src/main/resources/cluster.xml
+++ b/quickstart/vertx/eventbus/src/main/resources/cluster.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.6.xsd"
+           xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <properties>
+    <property name="hazelcast.mancenter.enabled">false</property>
+    <property name="hazelcast.memcache.enabled">false</property>
+    <property name="hazelcast.rest.enabled">false</property>
+    <property name="hazelcast.wait.seconds.before.join">0</property>
+    <property name="hazelcast.logging.type">jdk</property>
+
+    <!-- at the moment the discovery needs to be activated explicitly -->
+    <property name="hazelcast.discovery.enabled">true</property>
+
+  </properties>
+
+  <group>
+    <name>dev</name>
+    <password>dev-pass</password>
+  </group>
+  <management-center enabled="false">http://localhost:8080/mancenter</management-center>
+  <network>
+    <port auto-increment="true" port-count="10000">5701</port>
+    <outbound-ports>
+      <!--
+      Allowed port range when connecting to other nodes.
+      0 or * means use system provided port.
+      -->
+      <ports>0</ports>
+    </outbound-ports>
+    <join>
+      <multicast enabled="false"/>
+
+      <tcp-ip enabled="false"/>
+      <discovery-strategies>
+        <discovery-strategy enabled="true"
+                                class="com.noctarius.hazelcast.kubernetes.HazelcastKubernetesDiscoveryStrategy">
+          <properties>
+            <!-- configure discovery headless service  lookup -->
+            <property name="service-dns">vertx-eventbus-hz</property>
+          </properties>
+        </discovery-strategy>
+      </discovery-strategies>
+    </join>
+
+    <interfaces enabled="false">
+      <interface>10.10.1.*</interface>
+    </interfaces>
+    <ssl enabled="false"/>
+    <socket-interceptor enabled="false"/>
+    <symmetric-encryption enabled="false">
+      <!--
+         encryption algorithm such as
+         DES/ECB/PKCS5Padding,
+         PBEWithMD5AndDES,
+         AES/CBC/PKCS5Padding,
+         Blowfish,
+         DESede
+      -->
+      <algorithm>PBEWithMD5AndDES</algorithm>
+      <!-- salt value to use when generating the secret key -->
+      <salt>thesalt</salt>
+      <!-- pass phrase to use when generating the secret key -->
+      <password>thepass</password>
+      <!-- iteration count to use when generating the secret key -->
+      <iteration-count>19</iteration-count>
+    </symmetric-encryption>
+  </network>
+  <partition-group enabled="false"/>
+  <executor-service name="default">
+    <pool-size>16</pool-size>
+    <!--Queue capacity. 0 means Integer.MAX_VALUE.-->
+    <queue-capacity>0</queue-capacity>
+  </executor-service>
+  <map name="__vertx.subs">
+
+    <!--
+        Number of backups. If 1 is set as the backup-count for example,
+        then all entries of the map will be copied to another JVM for
+        fail-safety. 0 means no backup.
+    -->
+    <backup-count>1</backup-count>
+    <!--
+  Maximum number of seconds for each entry to stay in the map. Entries that are
+  older than <time-to-live-seconds> and not updated for <time-to-live-seconds>
+  will get automatically evicted from the map.
+  Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+-->
+    <time-to-live-seconds>0</time-to-live-seconds>
+    <!--
+  Maximum number of seconds for each entry to stay idle in the map. Entries that are
+  idle(not touched) for more than <max-idle-seconds> will get
+  automatically evicted from the map. Entry is touched if get, put or containsKey is called.
+  Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+-->
+    <max-idle-seconds>0</max-idle-seconds>
+    <!--
+        Valid values are:
+        NONE (no eviction),
+        LRU (Least Recently Used),
+        LFU (Least Frequently Used).
+        NONE is the default.
+    -->
+    <eviction-policy>NONE</eviction-policy>
+    <!--
+        Maximum size of the map. When max size is reached,
+        map is evicted based on the policy defined.
+        Any integer between 0 and Integer.MAX_VALUE. 0 means
+        Integer.MAX_VALUE. Default is 0.
+    -->
+    <max-size policy="PER_NODE">0</max-size>
+    <!--
+        When max. size is reached, specified percentage of
+        the map will be evicted. Any integer between 0 and 100.
+        If 25 is set for example, 25% of the entries will
+        get evicted.
+    -->
+    <eviction-percentage>25</eviction-percentage>
+    <!--
+        While recovering from split-brain (network partitioning),
+        map entries in the small cluster will merge into the bigger cluster
+        based on the policy set here. When an entry merge into the
+        cluster, there might an existing entry with the same key already.
+        Values of these entries might be different for that same key.
+        Which value should be set for the key? Conflict is resolved by
+        the policy set here. Default policy is PutIfAbsentMapMergePolicy
+
+        There are built-in merge policies such as
+        com.hazelcast.map.merge.PassThroughMergePolicy; entry will be added if there is no existing entry for the key.
+        com.hazelcast.map.merge.PutIfAbsentMapMergePolicy ; entry will be added if the merging entry doesn't exist in the cluster.
+        com.hazelcast.map.merge.HigherHitsMapMergePolicy ; entry with the higher hits wins.
+        com.hazelcast.map.merge.LatestUpdateMapMergePolicy ; entry with the latest update wins.
+    -->
+    <merge-policy>com.hazelcast.map.merge.LatestUpdateMapMergePolicy</merge-policy>
+
+  </map>
+
+  <!-- Used internally in Vert.x to implement async locks -->
+  <semaphore name="__vertx.*">
+    <initial-permits>1</initial-permits>
+  </semaphore>
+
+</hazelcast>

--- a/quickstart/vertx/pom.xml
+++ b/quickstart/vertx/pom.xml
@@ -33,6 +33,8 @@
 
   <modules>
     <module>simplest</module>
+    <module>chat</module>
+    <module>eventbus</module>
   </modules>
 
 </project>

--- a/quickstart/vertx/pom.xml
+++ b/quickstart/vertx/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>io.fabric8.quickstarts</groupId>
     <artifactId>fabric8-quickstart-parent</artifactId>
-    <version>2.2.90-SNAPSHOT</version>
+    <version>2.2.91-SNAPSHOT</version>
   </parent>
 
   <artifactId>vertx</artifactId>

--- a/quickstart/vertx/simplest/pom.xml
+++ b/quickstart/vertx/simplest/pom.xml
@@ -24,11 +24,11 @@
   <parent>
     <groupId>io.fabric8.quickstarts</groupId>
     <artifactId>vertx</artifactId>
-    <version>2.2.90-SNAPSHOT</version>
+    <version>2.2.91-SNAPSHOT</version>
   </parent>
 
   <artifactId>vertx-simplest</artifactId>
-  <version>2.2.90-SNAPSHOT</version>
+  <version>2.2.91-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Fabric8 :: Quickstarts :: Vert.x :: Simplest fat jar</name>

--- a/quickstart/vertx/simplest/src/main/java/io/fabric8/quickstarts/vertxsimplest/HelloWorldEmbedded.java
+++ b/quickstart/vertx/simplest/src/main/java/io/fabric8/quickstarts/vertxsimplest/HelloWorldEmbedded.java
@@ -1,4 +1,4 @@
-package io.vertx.example;
+package io.fabric8.quickstarts.vertxsimplest;
 
 import io.vertx.core.Vertx;
 


### PR DESCRIPTION
Implement a clustered chat and a clustered eventbus example.

These examples use the Hazelcast k8s discovery plugin to locate other Vert.x/HZ nodes in the k8s cluster.

Note that the HZ k8s plugin is only available in >= HZ 3.6 so we override the transitive HZ dependency to include HZ 3.6-EA2. Also we rely on a snapshot for the discovery plugin itself as the previous DNS lookup functionality was broken (fixed by @jimmidyson)
