### PR TITLE
lets use a ribbon SA for the spring-boot-ribbon quickstart and lets add the service paths to HTTP based quickstarts that don't use / as the entrypoint

### DIFF
--- a/quickstart/cdi/camel-http/pom.xml
+++ b/quickstart/cdi/camel-http/pom.xml
@@ -66,6 +66,8 @@
     <fabric8.metrics.port>9779</fabric8.metrics.port>
     <!-- End Prometheus metrics stuff -->
 
+    <fabric8.annotations.service.servicepath>/camel/hello</fabric8.annotations.service.servicepath>
+
     <fabric8.label.group>quickstarts</fabric8.label.group>
     <fabric8.iconRef>camel</fabric8.iconRef>
   </properties>

--- a/quickstart/cdi/camel-jetty/pom.xml
+++ b/quickstart/cdi/camel-jetty/pom.xml
@@ -58,6 +58,8 @@
     <fabric8.service.containerPort>8080</fabric8.service.containerPort>
     <fabric8.service.type>LoadBalancer</fabric8.service.type>
 
+    <fabric8.annotations.service.servicepath>/camel/hello</fabric8.annotations.service.servicepath>
+
     <fabric8.readinessProbe.httpGet.port>8080</fabric8.readinessProbe.httpGet.port>
     <fabric8.readinessProbe.httpGet.path>/camel/hello</fabric8.readinessProbe.httpGet.path>
     <fabric8.readinessProbe.timeoutSeconds>30</fabric8.readinessProbe.timeoutSeconds>

--- a/quickstart/cdi/camel-swagger/pom.xml
+++ b/quickstart/cdi/camel-swagger/pom.xml
@@ -60,6 +60,8 @@
     <fabric8.service.containerPort>${http.port}</fabric8.service.containerPort>
     <fabric8.service.type>LoadBalancer</fabric8.service.type>
 
+     <fabric8.annotations.service.servicepath>/user</fabric8.annotations.service.servicepath>
+
     <fabric8.readinessProbe.httpGet.port>${http.port}</fabric8.readinessProbe.httpGet.port>
     <fabric8.readinessProbe.httpGet.path>/swagger.json</fabric8.readinessProbe.httpGet.path>
     <fabric8.readinessProbe.timeoutSeconds>30</fabric8.readinessProbe.timeoutSeconds>

--- a/quickstart/spring-boot/ribbon/pom.xml
+++ b/quickstart/spring-boot/ribbon/pom.xml
@@ -56,7 +56,12 @@
 		<fabric8.service.port>80</fabric8.service.port>
 		<fabric8.service.containerPort>8080</fabric8.service.containerPort>
 		<fabric8.service.type>LoadBalancer</fabric8.service.type>
-		<fabric8.serviceAccount>fabric8</fabric8.serviceAccount>
+
+		<fabric8.annotations.service.servicepath>/hello</fabric8.annotations.service.servicepath>
+
+		<fabric8.serviceAccount>ribbon</fabric8.serviceAccount>
+		<fabric8.serviceAccountCreate>true</fabric8.serviceAccountCreate>
+
 		<fabric8.label.hystrix.enabled>true</fabric8.label.hystrix.enabled>
 		<fabric8.label.hystrix.cluster>default</fabric8.label.hystrix.cluster>
 	</properties>

--- a/quickstart/war/camel-servlet/pom.xml
+++ b/quickstart/war/camel-servlet/pom.xml
@@ -57,6 +57,8 @@
     <fabric8.service.containerPort>8080</fabric8.service.containerPort>
     <fabric8.service.type>LoadBalancer</fabric8.service.type>
 
+    <fabric8.annotations.service.servicepath>/hello</fabric8.annotations.service.servicepath>
+
     <fabric8.readinessProbe.httpGet.port>8080</fabric8.readinessProbe.httpGet.port>
     <fabric8.readinessProbe.httpGet.path>/</fabric8.readinessProbe.httpGet.path>
     <fabric8.readinessProbe.timeoutSeconds>30</fabric8.readinessProbe.timeoutSeconds>


### PR DESCRIPTION
lets use a ribbon SA for the spring-boot-ribbon quickstart and lets add the service paths to HTTP based quickstarts that don't use / as the entrypoint