### PR TITLE
Add missing Jackson dependencies required by Swagger

### DIFF
--- a/quickstart/cdi/cxf/pom.xml
+++ b/quickstart/cdi/cxf/pom.xml
@@ -39,8 +39,6 @@
     <fabric8.version>2.2.114</fabric8.version>
     <docker.maven.plugin.version>0.15.1</docker.maven.plugin.version>
 
-
-
     <!-- configure the versions you want to use here -->
     <cxf.version>3.1.4</cxf.version>
     <cxf.plugin.version>3.1.4</cxf.plugin.version>
@@ -48,6 +46,8 @@
     <weld.version>2.3.3.Final</weld.version>
     <slf4j-version>1.7.12</slf4j-version>
     <swagger-version>1.5.7</swagger-version>
+    <!-- Use same version as Swagger -->
+    <jackson.version>2.4.5</jackson.version>
 
     <http.port>9092</http.port>
 
@@ -272,6 +272,7 @@
       <version>${jetty-version}</version>
     </dependency>
 
+    <!-- Swagger -->
     <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-jaxrs</artifactId>
@@ -284,6 +285,23 @@
           <artifactId>jsr311-api</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+
+    <!-- Jackson dependencies required by Swagger -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>${jackson.version}</version>
     </dependency>
 
     <!-- logging -->


### PR DESCRIPTION
- Include the artifacts of the missing Jackson dependencies required by Swagger
- Add the version number of jackson to the pom file
- Use same version of jackson as supported by Swagger