### PR TITLE
#956: Switch to java-s2i image, fixed console and s2i build

### DIFF
--- a/quickstart/spring-boot/camel/pom.xml
+++ b/quickstart/spring-boot/camel/pom.xml
@@ -43,7 +43,7 @@
     <spring-boot.version>1.3.5.RELEASE</spring-boot.version>
 
     <!-- Docker & Fabric8 Configs -->
-    <docker.from>fabric8/java-jboss-openjdk8-jdk:1.0.13</docker.from>
+    <docker.from>fabric8/s2i-java:1.2</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
     <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
 
@@ -130,7 +130,7 @@
 
   <build>
     <plugins>
-      <!-- Compiler plugin enforces Java 1.7 compatibility and activates annotation processors -->
+      <!-- Compiler plugin enforces Java 1.8 compatibility and activates annotation processors -->
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.3</version>
@@ -188,6 +188,23 @@
 
       <plugin>
         <groupId>io.fabric8</groupId>
+        <artifactId>hawt-app-maven-plugin</artifactId>
+        <version>${fabric8.version}</version>
+        <executions>
+          <execution>
+            <id>hawt-app</id>
+            <goals>
+              <goal>build</goal>
+            </goals>
+            <configuration>
+              <javaMainClass>io.fabric8.quickstarts.camel.MyCamelRoute</javaMainClass>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
         <version>${docker.maven.plugin.version}</version>
         <configuration>
@@ -197,11 +214,12 @@
               <build>
                 <from>${docker.from}</from>
                 <assembly>
-                  <basedir>/app</basedir>
-                  <descriptorRef>artifact</descriptorRef>
+                  <basedir>/deployments</basedir>
+                  <descriptorRef>hawt-app</descriptorRef>
                 </assembly>
                 <env>
-                  <JAVA_APP_JAR>${project.build.finalName}.jar</JAVA_APP_JAR>
+                  <JAVA_LIB_DIR>/deployments/lib</JAVA_LIB_DIR>
+                  <JAVA_MAIN_CLASS>io.fabric8.quickstarts.camel.MyCamelRoute</JAVA_MAIN_CLASS>
                 </env>
               </build>
             </image>

--- a/quickstart/spring-boot/camel/quickstart-template.json
+++ b/quickstart/spring-boot/camel/quickstart-template.json
@@ -4,7 +4,7 @@
   "labels": {},
   "metadata": {
     "annotations": {
-      "description": "# Spring-Boot Camel QuickStart\n\nThis example demonstrates how you can use Apache Camel with Spring Boot\nbased on a [fabric8 Java base image](https://github.com/fabric8io/base-images#java-base-images)\n\nThe quickstart uses Spring Boot to configure a little application that includes a Camel\nroute that triggeres a message every 5th second, and routes the message to a log.\n\n\n### Building\n\nThe example can be built with\n\n    mvn clean install\n\n\n### Running the example locally\n\nThe example can be run locally using the following Maven goal:\n\n    mvn spring-boot:run\n\n\n### Running the example in fabric8\n\nIt is assumed a running Kubernetes platform is already running. If not you can find details how to [get started](http://fabric8.io/guide/getStarted/index.html).\n\nThe example can be built and deployed using a single goal:\n\n    mvn -Pf8-local-deploy\n\nWhen the example runs in fabric8, you can use the OpenShift client tool to inspect the status\n\nTo list all the running pods:\n\n    oc get pods\n\nThen find the name of the pod that runs this quickstart, and output the logs from the running pods with:\n\n    oc logs <name of pod>\n\nYou can also use the fabric8 [web console](http://fabric8.io/guide/console.html) to manage the\nrunning pods, and view logs and much more.\n\n\n### More details\n\nYou can find more details about running this [quickstart](http://fabric8.io/guide/quickstarts/running.html) on the website. This also includes instructions how to change the Docker image user and registry.\n\n",
+      "description": "# Spring-Boot Camel QuickStart\n\nThis example demonstrates how you can use Apache Camel with Spring Boot\nbased on a [fabric8 Java s2i image](https://github.com/fabric8io-images/s2i#java-s2i-builder-image)\n\nThe quickstart uses Spring Boot to configure a little application that includes a Camel\nroute that triggeres a message every 5th second, and routes the message to a log.\n\n\n### Building\n\nThe example can be built with\n\n    mvn clean install\n\n\n### Running the example locally\n\nThe example can be run locally using the following Maven goal:\n\n    mvn spring-boot:run\n\n\n### Running the example in fabric8\n\nIt is assumed a running Kubernetes platform is already running. If not you can find details how to [get started](http://fabric8.io/guide/getStarted/index.html).\n\nThe example can be built and deployed using a single goal:\n\n    mvn -Pf8-local-deploy\n\nWhen the example runs in fabric8, you can use the OpenShift client tool to inspect the status\n\nTo list all the running pods:\n\n    oc get pods\n\nThen find the name of the pod that runs this quickstart, and output the logs from the running pods with:\n\n    oc logs <name of pod>\n\nYou can also use the fabric8 [web console](http://fabric8.io/guide/console.html) to manage the\nrunning pods, and view logs and much more.\n\n\n### More details\n\nYou can find more details about running this [quickstart](http://fabric8.io/guide/quickstarts/running.html) on the website. This also includes instructions how to change the Docker image user and registry.\n\n",
       "iconClass": "icon-java"
     },
     "labels": {},
@@ -33,7 +33,7 @@
     },
     {
       "name": "BUILDER_VERSION",
-      "value": "1.2.5",
+      "value": "1.2.9",
       "description": "Builder version"
     },
     {
@@ -78,7 +78,7 @@
         }
       },
       "spec": {
-        "dockerImageRepository": "fabric8/s2i-java:${BUILDER_VERSION}"
+        "dockerImageRepository": "fabric8/s2i-java"
       },
       "status": {
         "dockerImageRepository": ""


### PR DESCRIPTION
I think it's time to use the java-s2i image for the spring-boot quickstart. 

This patch fixes the issue with the visualization of the jolokia console (https://github.com/fabric8io/ipaas-quickstarts/issues/956).

I also fixed the template.json file for s2i. According to https://github.com/openshift/origin/issues/3487, tags are not allowed in the "dockerImageRepository" element.
I removed the tag indication and verified that the correct tag is still used (it is referenced in the BuildConfig section).