### PR TITLE
Fixed file permission issues for camel-amq quickstart

### DIFF
--- a/quickstart/spring-boot/camel-amq/src/main/resources/META-INF/spring/camel-context.xml
+++ b/quickstart/spring-boot/camel-amq/src/main/resources/META-INF/spring/camel-context.xml
@@ -8,41 +8,37 @@
     <!-- Camel Route -->
     <camelContext xmlns="http://camel.apache.org/schema/spring">
 
-        <!-- a route to generate a random order every 5th second -->
-        <route id="generate-order">
-            <from uri="timer:order?period=5000"/>
-            <bean ref="orderGenerator" method="generateOrder"/>
-            <setHeader headerName="Exchange.FILE_NAME">
-                <method ref="orderGenerator" method="generateFileName"/>
-            </setHeader>
-            <to uri="file:work/jms/input"/>
-        </route>
-
         <!--
-          When this route is started, it will automatically create the work/jms/input directory where you can drop the
-          file that need to be processed.
+          A route to generate a random order every 5th second.
+
+          When this route is started, it will automatically send xml messages to the JMS queue incomingOrders on the
+          ActiveMQ broker.
 
           The <log/> elements are used to add human-friendly business logging statements. They make it easier to see what the
           route is doing.
 
-          Files that are consumed from the work/jms/input directory, are then sent to the JMS queue incomingOrders on the
-          ActiveMQ broker.
-
-          The amq component is from fabric8 that ensures to use the broker in the kubernetes cluster
+          The amq component ensures to use the broker in the kubernetes cluster.
         -->
-        <route id="file-to-jms-route">
-            <from uri="file:work/jms/input"/>
-            <log message="Receiving order ${file:name}"/>
+        <route id="generate-order">
+            <from uri="timer:order?period=5000"/>
+            <bean ref="orderGenerator" method="generateOrder"/>
+            <setHeader headerName="Exchange.FILE_NAME">
+                <!-- defining the header containing a simulated file name -->
+                <method ref="orderGenerator" method="generateFileName"/>
+            </setHeader>
+
+            <log message="Generating order ${file:name}"/>
             <to uri="amq:incomingOrders"/>
         </route>
+
 
         <!--
           This route consumes messages from the JMS queue incomingOrders on the ActiveMQ broker within the ESB.
 
           The <choice/> element contains the content based router. The two <when/> clauses use XPath to define the criteria
-          for entering that part of the route. When the country in the XML message is set to UK or US, the file will be
-          moved to a directory for that country. The <otherwise/> element ensures that any file that does not meet the
-          requirements for either of the <when/> elements will be moved to the work/jms/output/others directory.
+          for entering that part of the route. When the country in the XML message is set to UK or US, the message will follow
+          the specific rules defined for that country. The <otherwise/> element ensures that any message that does not meet the
+          requirements for either of the <when/> elements will follow another route.
         -->
         <route id="jms-cbr-route" streamCache="true">
             <from uri="amq:incomingOrders"/>
@@ -50,16 +46,16 @@
                 <when>
                     <xpath>/order/customer/country = 'UK'</xpath>
                     <log message="Sending order ${file:name} to the UK"/>
-                    <to uri="file:work/jms/output/uk"/>
+                    <!-- Put additional routing rules for UK messages here -->
                 </when>
                 <when>
                     <xpath>/order/customer/country = 'US'</xpath>
                     <log message="Sending order ${file:name} to the US"/>
-                    <to uri="file:work/jms/output/us"/>
+                    <!-- Put additional routing rules for US messages here -->
                 </when>
                 <otherwise>
                     <log message="Sending order ${file:name} to another country"/>
-                    <to uri="file:work/jms/output/others"/>
+                    <!-- Put additional routing rules for other messages here -->
                 </otherwise>
             </choice>
             <log message="Done processing ${file:name}"/>

--- a/quickstart/spring-boot/camel-amq/src/main/resources/data/order1.xml
+++ b/quickstart/spring-boot/camel-amq/src/main/resources/data/order1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
     <customer id="A0001">
         <name>Antwerp Zoo</name>

--- a/quickstart/spring-boot/camel-amq/src/main/resources/data/order2.xml
+++ b/quickstart/spring-boot/camel-amq/src/main/resources/data/order2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
     <customer id="B0002">
         <name>Bristol Zoo Gardens</name>

--- a/quickstart/spring-boot/camel-amq/src/main/resources/data/order3.xml
+++ b/quickstart/spring-boot/camel-amq/src/main/resources/data/order3.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
     <customer id="C0003">
         <name>Columbus Zoo and Aquarium</name>

--- a/quickstart/spring-boot/camel-amq/src/main/resources/data/order4.xml
+++ b/quickstart/spring-boot/camel-amq/src/main/resources/data/order4.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
     <customer id="D0004">
         <name>Dartmoor Zoological Park</name>

--- a/quickstart/spring-boot/camel-amq/src/main/resources/data/order5.xml
+++ b/quickstart/spring-boot/camel-amq/src/main/resources/data/order5.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
     <customer id="E0004">
         <name>Erie Zoo</name>


### PR DESCRIPTION
Due to file permission issues on some docker images, I removed the routes-to-files from the camel-amq quickstart. I also fixed sample files to comply with xpath expressions defined in the routes.