### PR TITLE
lets use fabric8.image instead of docker.image to avoid breaking docker-maven-plugin

### DIFF
--- a/quickstart/cdi/camel-http/pom.xml
+++ b/quickstart/cdi/camel-http/pom.xml
@@ -50,7 +50,7 @@
     <!-- Docker & Fabric8 Configs -->
     <docker.from>fabric8/java-jboss-openjdk8-jdk:1.1.5</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
-    <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
+    <fabric8.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</fabric8.image>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
 
     <!--
@@ -237,7 +237,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${fabric8.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/quickstart/cdi/camel-jetty/pom.xml
+++ b/quickstart/cdi/camel-jetty/pom.xml
@@ -49,7 +49,7 @@
     <!-- Docker & Fabric8 Configs -->
     <docker.from>fabric8/java-jboss-openjdk8-jdk:1.1.5</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
-    <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
+    <fabric8.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</fabric8.image>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>8080</docker.port.container.http>
 
@@ -238,7 +238,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${fabric8.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/quickstart/cdi/camel-mq/pom.xml
+++ b/quickstart/cdi/camel-mq/pom.xml
@@ -51,7 +51,7 @@
     <!-- Docker & Fabric8 Configs -->
     <docker.from>fabric8/java-jboss-openjdk8-jdk:1.1.5</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
-    <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
+    <fabric8.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</fabric8.image>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
 
     <!--
@@ -256,7 +256,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${fabric8.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/quickstart/cdi/camel-swagger/pom.xml
+++ b/quickstart/cdi/camel-swagger/pom.xml
@@ -51,7 +51,7 @@
     <!-- Docker & Fabric8 Configs -->
     <docker.from>fabric8/java-jboss-openjdk8-jdk:1.1.5</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
-    <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
+    <fabric8.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</fabric8.image>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>${http.port}</docker.port.container.http>
 
@@ -264,7 +264,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${fabric8.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/quickstart/cdi/camel/pom.xml
+++ b/quickstart/cdi/camel/pom.xml
@@ -48,7 +48,7 @@
     <!-- Docker & Fabric8 Configs -->
     <docker.from>fabric8/java-jboss-openjdk8-jdk:1.1.5</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
-    <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
+    <fabric8.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</fabric8.image>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
 
     <!--
@@ -266,7 +266,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${fabric8.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/quickstart/cdi/cxf/pom.xml
+++ b/quickstart/cdi/cxf/pom.xml
@@ -52,7 +52,7 @@
     <!-- Docker & Fabric8 Configs -->
     <docker.from>fabric8/java-jboss-openjdk8-jdk:1.1.5</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
-    <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
+    <fabric8.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</fabric8.image>
     <docker.port.container.http>${http.port}</docker.port.container.http>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.metrics>9779</docker.port.container.metrics>
@@ -478,7 +478,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${fabric8.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/quickstart/infinispan/infinispan-client/pom.xml
+++ b/quickstart/infinispan/infinispan-client/pom.xml
@@ -31,7 +31,7 @@
     <!-- Docker & Fabric8 Configs -->
     <docker.from>fabric8/java-jboss-openjdk8-jdk:1.1.5</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
-    <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
+    <fabric8.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</fabric8.image>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
 
     <!--
@@ -194,7 +194,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${fabric8.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/quickstart/infinispan/infinispan-server/pom.xml
+++ b/quickstart/infinispan/infinispan-server/pom.xml
@@ -28,7 +28,7 @@
 
     <docker.from>jboss/infinispan-server</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
-    <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
+    <fabric8.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</fabric8.image>
     <docker.assemblyDescriptorRef>artifact</docker.assemblyDescriptorRef>
 
     <fabric8.service.name>${project.artifactId}</fabric8.service.name>
@@ -85,7 +85,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${fabric8.image}</name>
               <build>
                 <from>${docker.from}</from>
               </build>

--- a/quickstart/java/camel-spring/pom.xml
+++ b/quickstart/java/camel-spring/pom.xml
@@ -48,7 +48,7 @@
     <!-- Docker & Fabric8 Configs -->
     <docker.from>fabric8/java-jboss-openjdk8-jdk:1.1.5</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
-    <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
+    <fabric8.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</fabric8.image>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
 
     <!--
@@ -208,7 +208,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${fabric8.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/quickstart/java/fatjar/pom.xml
+++ b/quickstart/java/fatjar/pom.xml
@@ -44,7 +44,7 @@
     <!-- Docker & Fabric8 Configs -->
     <docker.from>fabric8/java-jboss-openjdk8-jdk:1.1.5</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
-    <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
+    <fabric8.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</fabric8.image>
 
     <fabric8.label.group>quickstarts</fabric8.label.group>
     <fabric8.iconRef>java</fabric8.iconRef>
@@ -135,7 +135,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${fabric8.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/quickstart/java/mainclass/pom.xml
+++ b/quickstart/java/mainclass/pom.xml
@@ -44,7 +44,7 @@
     <!-- Docker & Fabric8 Configs -->
     <docker.from>fabric8/java-jboss-openjdk8-jdk:1.1.5</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
-    <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
+    <fabric8.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</fabric8.image>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
 
     <fabric8.label.group>quickstarts</fabric8.label.group>
@@ -130,7 +130,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${fabric8.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/quickstart/karaf/camel-amq/pom.xml
+++ b/quickstart/karaf/camel-amq/pom.xml
@@ -48,7 +48,7 @@
 
     <docker.from>fabric8/s2i-karaf:1.2</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
-    <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
+    <fabric8.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</fabric8.image>
     <docker.assemblyDescriptor>${basedir}/src/main/fabric8/assembly.xml</docker.assemblyDescriptor>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>8181</docker.port.container.http>
@@ -279,7 +279,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${fabric8.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/quickstart/karaf/camel-log/pom.xml
+++ b/quickstart/karaf/camel-log/pom.xml
@@ -50,7 +50,7 @@
 
     <docker.from>fabric8/s2i-karaf:1.2</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
-    <docker.image>${fabric8.dockerUser}quickstart-karaf-camellog:${project.version}</docker.image>
+    <fabric8.image>${fabric8.dockerUser}quickstart-karaf-camellog:${project.version}</fabric8.image>
     <docker.assemblyDescriptor>${basedir}/src/main/fabric8/assembly.xml</docker.assemblyDescriptor>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>8181</docker.port.container.http>
@@ -228,7 +228,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${fabric8.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/quickstart/karaf/camel-rest-sql/pom.xml
+++ b/quickstart/karaf/camel-rest-sql/pom.xml
@@ -52,7 +52,7 @@
 
     <docker.from>fabric8/s2i-karaf:1.2</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
-    <docker.image>${fabric8.dockerUser}quickstart-karaf-camelrest:${project.version}</docker.image>
+    <fabric8.image>${fabric8.dockerUser}quickstart-karaf-camelrest:${project.version}</fabric8.image>
     <docker.assemblyDescriptor>${basedir}/src/main/fabric8/assembly.xml</docker.assemblyDescriptor>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>8181</docker.port.container.http>
@@ -288,7 +288,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${fabric8.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/quickstart/spring-boot/camel-amq/pom.xml
+++ b/quickstart/spring-boot/camel-amq/pom.xml
@@ -33,7 +33,7 @@
         <!-- Docker & Fabric8 Configs -->
         <docker.from>fabric8/java-jboss-openjdk8-jdk:1.1.5</docker.from>
         <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
-        <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
+        <fabric8.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</fabric8.image>
 
         <fabric8.label.group>quickstarts</fabric8.label.group>
         <fabric8.iconRef>camel</fabric8.iconRef>
@@ -181,7 +181,7 @@
                 <configuration>
                     <images>
                         <image>
-                            <name>${docker.image}</name>
+                            <name>${fabric8.image}</name>
                             <build>
                                 <from>${docker.from}</from>
                                 <assembly>

--- a/quickstart/spring-boot/camel-drools/pom.xml
+++ b/quickstart/spring-boot/camel-drools/pom.xml
@@ -47,7 +47,7 @@
         <!-- Docker & Fabric8 Configs -->
         <docker.from>fabric8/java-jboss-openjdk8-jdk:1.1.5</docker.from>
         <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
-        <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
+        <fabric8.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</fabric8.image>
 
         <fabric8.label.group>quickstarts</fabric8.label.group>
         <fabric8.iconRef>camel</fabric8.iconRef>
@@ -225,7 +225,7 @@
                 <configuration>
                     <images>
                         <image>
-                            <name>${docker.image}</name>
+                            <name>${fabric8.image}</name>
                             <build>
                                 <from>${docker.from}</from>
                                 <assembly>

--- a/quickstart/spring-boot/camel-teiid/pom.xml
+++ b/quickstart/spring-boot/camel-teiid/pom.xml
@@ -47,7 +47,7 @@
         <!-- Docker & Fabric8 Configs -->
         <docker.from>fabric8/java-jboss-openjdk8-jdk:1.0.13</docker.from>
         <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
-        <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
+        <fabric8.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</fabric8.image>
 
         <fabric8.label.group>quickstarts</fabric8.label.group>
         <fabric8.iconRef>camel</fabric8.iconRef>
@@ -201,7 +201,7 @@
                 <configuration>
                     <images>
                         <image>
-                            <name>${docker.image}</name>
+                            <name>${fabric8.image}</name>
                             <build>
                                 <from>${docker.from}</from>
                                 <assembly>

--- a/quickstart/spring-boot/hystrix/pom.xml
+++ b/quickstart/spring-boot/hystrix/pom.xml
@@ -50,7 +50,7 @@
 
     <docker.from>fabric8/java-jboss-openjdk8-jdk:1.1.5</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
-    <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
+    <fabric8.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</fabric8.image>
     <docker.port.container.http>8080</docker.port.container.http>
 
     <fabric8.service.name>${project.artifactId}</fabric8.service.name>
@@ -222,7 +222,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${fabric8.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/quickstart/spring-boot/ribbon/pom.xml
+++ b/quickstart/spring-boot/ribbon/pom.xml
@@ -50,7 +50,7 @@
 
     <docker.from>fabric8/java-jboss-openjdk8-jdk:1.1.5</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
-    <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
+    <fabric8.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</fabric8.image>
     <docker.port.container.http>8080</docker.port.container.http>
 
     <fabric8.service.name>${project.artifactId}</fabric8.service.name>
@@ -269,7 +269,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${fabric8.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/quickstart/spring-boot/webmvc/pom.xml
+++ b/quickstart/spring-boot/webmvc/pom.xml
@@ -43,7 +43,7 @@
     <!-- Docker & Fabric8 Configs -->
     <docker.from>fabric8/java-jboss-openjdk8-jdk:1.1.5</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
-    <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
+    <fabric8.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</fabric8.image>
 
     <fabric8.service.name>${project.artifactId}</fabric8.service.name>
     <fabric8.service.port>80</fabric8.service.port>
@@ -174,7 +174,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${fabric8.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/quickstart/vertx/simplest/pom.xml
+++ b/quickstart/vertx/simplest/pom.xml
@@ -45,7 +45,7 @@
     <!-- Docker & Fabric8 Configs -->
     <docker.from>fabric8/java-jboss-openjdk8-jdk:1.1.5</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
-    <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
+    <fabric8.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</fabric8.image>
 
     <fabric8.service.name>${project.artifactId}</fabric8.service.name>
     <fabric8.service.port>80</fabric8.service.port>
@@ -162,7 +162,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${fabric8.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/quickstart/war/camel-servlet/pom.xml
+++ b/quickstart/war/camel-servlet/pom.xml
@@ -47,7 +47,7 @@
 
     <docker.from>fabric8/tomcat-8</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
-    <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
+    <fabric8.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</fabric8.image>
     <docker.assemblyDescriptorRef>rootWar</docker.assemblyDescriptorRef>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>8080</docker.port.container.http>
@@ -148,7 +148,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${fabric8.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/quickstart/war/cxf-cdi-servlet/pom.xml
+++ b/quickstart/war/cxf-cdi-servlet/pom.xml
@@ -49,7 +49,7 @@
 
     <docker.from>fabric8/tomcat-8.0</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
-    <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
+    <fabric8.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</fabric8.image>
     <docker.assemblyDescriptorRef>rootWar</docker.assemblyDescriptorRef>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>8080</docker.port.container.http>
@@ -264,7 +264,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${fabric8.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/quickstart/war/wildfly/pom.xml
+++ b/quickstart/war/wildfly/pom.xml
@@ -45,7 +45,7 @@
 
     <docker.from>jboss/wildfly:10.0.0.Final</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
-    <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
+    <fabric8.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</fabric8.image>
     <docker.assemblyDescriptorRef>artifact</docker.assemblyDescriptorRef>
 
     <fabric8.service.name>${project.artifactId}</fabric8.service.name>
@@ -113,7 +113,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${fabric8.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/quickstart/wildfly/camel-cdi/pom.xml
+++ b/quickstart/wildfly/camel-cdi/pom.xml
@@ -46,7 +46,7 @@
 
     <docker.from>wildflyext/wildfly-camel:${wildfly.camel.version}</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
-    <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
+    <fabric8.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</fabric8.image>
     <docker.assemblyDescriptorRef>artifact</docker.assemblyDescriptorRef>
 
     <fabric8.service.name>${project.artifactId}</fabric8.service.name>
@@ -111,7 +111,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${fabric8.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/quickstart/wildfly/camel-ejb/pom.xml
+++ b/quickstart/wildfly/camel-ejb/pom.xml
@@ -46,7 +46,7 @@
 
     <docker.from>wildflyext/wildfly-camel:${wildfly.camel.version}</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
-    <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
+    <fabric8.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</fabric8.image>
     <docker.assemblyDescriptorRef>artifact</docker.assemblyDescriptorRef>
 
     <fabric8.service.name>${project.artifactId}</fabric8.service.name>
@@ -111,7 +111,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${fabric8.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/quickstart/wildfly/camel-jaxrs/pom.xml
+++ b/quickstart/wildfly/camel-jaxrs/pom.xml
@@ -46,7 +46,7 @@
 
     <docker.from>wildflyext/wildfly-camel:${wildfly.camel.version}</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
-    <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
+    <fabric8.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</fabric8.image>
     <docker.assemblyDescriptorRef>artifact</docker.assemblyDescriptorRef>
 
     <fabric8.service.name>${project.artifactId}</fabric8.service.name>
@@ -111,7 +111,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${fabric8.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/quickstart/wildfly/camel-jaxws/pom.xml
+++ b/quickstart/wildfly/camel-jaxws/pom.xml
@@ -46,7 +46,7 @@
 
     <docker.from>wildflyext/wildfly-camel:${wildfly.camel.version}</docker.from>
     <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
-    <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
+    <fabric8.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</fabric8.image>
     <docker.assemblyDescriptorRef>artifact</docker.assemblyDescriptorRef>
 
     <fabric8.service.name>${project.artifactId}</fabric8.service.name>
@@ -111,7 +111,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${fabric8.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>


### PR DESCRIPTION
lets use fabric8.image instead of docker.image to avoid breaking docker-maven-plugin