### PR TITLE
OSFUSE-404: adding json resources in the archetypes

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -23,7 +23,7 @@ For example, `spring-boot-camel-archetype` is the name of a Camel quickstart tha
 The build requires Maven version 3.2.5 or later.
 
     mvn clean install
-    
+
 ### Running the system tests
 
 To run the system tests for all the quickstarts check out the [docs on how to run them](archetype-itests)

--- a/archetype-builder/src/main/resources/io/fabric8/tooling/archetype/builder/default-archetype-descriptor.xml
+++ b/archetype-builder/src/main/resources/io/fabric8/tooling/archetype/builder/default-archetype-descriptor.xml
@@ -43,6 +43,7 @@
         <include>**/*.sql</include>
         <include>**/*.yml</include>
         <include>**/*.yaml</include>
+        <include>**/*.json</include>
       </includes>
       <excludes>
         <exclude>java/**</exclude>
@@ -75,6 +76,7 @@
         <include>**/*.cfg</include>
         <include>**/*.yml</include>
         <include>**/*.yaml</include>
+        <include>**/*.json</include>
       </includes>
       <excludes>
         <exclude>java/**</exclude>


### PR DESCRIPTION
Json files are used in quickstarts to include additional resources in Kubernetes integration tests.