### PR TITLE
use the default settings.xml so we don't download all the dependencies…

### DIFF
--- a/archetype-itests/src/test/java/io/fabric8/tooling/archetype/generator/ArchetypeTest.java
+++ b/archetype-itests/src/test/java/io/fabric8/tooling/archetype/generator/ArchetypeTest.java
@@ -484,10 +484,6 @@ public class ArchetypeTest {
                             args = new String[]{"clean", "install", "-U", "-Dfabric8.mode=" + fabric8Mode};
                         }
                     }
-                    // using an itest settings.xml here similar to jboss-fuse archetypes configuration/settings.xml
-                    args = Arrays.copyOf(args, args.length + 2);
-                    args[args.length - 2] = "-s";
-                    args[args.length - 1] = new File(basedir, "target/test-classes/settings.xml").getAbsolutePath();
                     File logFile = new File(new File(outDir), "output.log");
                     logFile.delete();
                     resultPointer[0] = invokeMaven(args, outDir, logFile);


### PR DESCRIPTION
… again on each test run