### PR TITLE
updated transport to use http(s) url to prevent MiTM Attack

### DIFF
--- a/archetype-builder/src/main/java/io/fabric8/tooling/archetype/builder/ArchetypeBuilder.java
+++ b/archetype-builder/src/main/java/io/fabric8/tooling/archetype/builder/ArchetypeBuilder.java
@@ -98,7 +98,7 @@ public class ArchetypeBuilder extends AbstractBuilder{
         for (Map.Entry<String, GHRepository> entry : entries) {
             String repoName = entry.getKey();
             GHRepository repo = entry.getValue();
-            String url = repo.getGitTransportUrl();
+            String url = repo.gitHttpTransportUrl();
 
             generateArchetypeFromGitRepo(outputDir, dirs, cloneParentDir, repoName, url, null);
         }


### PR DESCRIPTION
Suggested change from security review of Obsidian by Red Hat Product Security